### PR TITLE
feat: enhance MktCustomer and MktLicense entities with new relations …

### DIFF
--- a/packages/twenty-server/src/mkt-core/constants/mkt-field-ids.ts
+++ b/packages/twenty-server/src/mkt-core/constants/mkt-field-ids.ts
@@ -28,6 +28,7 @@ export const MKT_CUSTOMER_FIELD_IDS = {
   salesId: '78be7072-50eb-4edc-81fc-c3e25658d7bd',
   supportId: 'a1ed4146-269d-46a5-ac7e-7cba043974e1',
   affiliateId: '940e3766-a147-4cf4-bd50-805b1c8c8880',
+  mktLicenses: '4ac28e1a-089a-45d3-9725-b40861e98b15',
   // common relations or fields
   position: 'e3ca3ebd-4812-4c82-abde-e14b13a01829',
   createdBy: '4e6d0176-22f4-4b25-bbf2-0a3ed6d7a5e1',
@@ -181,7 +182,7 @@ export const MKT_LICENSE_FIELD_IDS = {
   deviceInfo: '7dc3c246-0a81-48b0-9343-70bf0431dfca',
   notes: 'dbf0752c-ed7c-45eb-88c0-e390ec42aed0',
   // relations
-  person: '11a10308-2c5c-4322-847d-4ec12d056d9c',
+  mktCustomer: '11a10308-2c5c-4322-847d-4ec12d056d9c',
   mktSales: '4bb927d7-a6d2-4746-b771-731cb6ab9950', // nullable
   mktVariant: 'f2d1ae3c-12d8-4e24-8cb5-dc82d422f12b',
   mktAffiliate: '8e48e8f3-5ad3-4936-b570-e061ef2e5959', // nullable

--- a/packages/twenty-server/src/mkt-core/customer/constants/mkt-customer.constant.ts
+++ b/packages/twenty-server/src/mkt-core/customer/constants/mkt-customer.constant.ts
@@ -1,0 +1,251 @@
+import { FieldMetadataComplexOption } from 'src/engine/metadata-modules/field-metadata/dtos/options.input';
+
+export enum MKT_CUSTOMER_TYPE {
+  INDIVIDUAL = 'individual',
+  BUSINESS = 'business',
+  ORGANIZATION = 'organization',
+  OTHER = 'other',
+}
+
+export enum MKT_CUSTOMER_STATUS {
+  ACTIVE = 'active',
+  INACTIVE = 'inactive',
+  BLOCKED = 'blocked',
+  PROSPECTIVE = 'prospective',
+  OTHER = 'other',
+}
+
+export enum MKT_CUSTOMER_TIER {
+  INDIVIDUAL = 'individual',
+  SMALL = 'small',
+  MEDIUM = 'medium',
+  ENTERPRISE = 'enterprise',
+  OTHER = 'other',
+}
+
+export enum MKT_CUSTOMER_LIFECYCLE_STAGE {
+  PROSPECTIVE = 'prospective',
+  TRIAL = 'trial',
+  CUSTOMER = 'customer',
+  LOYAL = 'loyal',
+  CHURNED = 'churned',
+  RETENTION = 'retention',
+  UPSELL = 'upsell',
+  CROSS_SELL = 'cross_sell',
+  REACTIVATION = 'reactivation',
+  OTHER = 'other',
+}
+
+export enum MKT_CUSTOMER_TAGS {
+  NEW = 'new',
+  RETURNING = 'returning',
+  LOYAL = 'loyal',
+  VIP = 'vip',
+  CHURNED = 'churned',
+  RETENTION = 'retention',
+  TECHNICAL = 'technical',
+  OTHER = 'other',
+}
+
+export const MKT_CUSTOMER_TYPE_OPTIONS: FieldMetadataComplexOption[] = [
+  {
+    value: MKT_CUSTOMER_TYPE.INDIVIDUAL,
+    label: 'Individual',
+    color: 'blue',
+    position: 1,
+  },
+  {
+    value: MKT_CUSTOMER_TYPE.BUSINESS,
+    label: 'Business',
+    color: 'green',
+    position: 2,
+  },
+  {
+    value: MKT_CUSTOMER_TYPE.ORGANIZATION,
+    label: 'Organization',
+    color: 'red',
+    position: 3,
+  },
+  {
+    value: MKT_CUSTOMER_TYPE.OTHER,
+    label: 'Other',
+    color: 'gray',
+    position: 4,
+  },
+];
+
+export const MKT_CUSTOMER_STATUS_OPTIONS: FieldMetadataComplexOption[] = [
+  {
+    value: MKT_CUSTOMER_STATUS.ACTIVE,
+    label: 'Active',
+    color: 'blue',
+    position: 1,
+  },
+  {
+    value: MKT_CUSTOMER_STATUS.INACTIVE,
+    label: 'Inactive',
+    color: 'gray',
+    position: 2,
+  },
+  {
+    value: MKT_CUSTOMER_STATUS.BLOCKED,
+    label: 'Blocked',
+    color: 'red',
+    position: 3,
+  },
+  {
+    value: MKT_CUSTOMER_STATUS.PROSPECTIVE,
+    label: 'Prospective',
+    color: 'yellow',
+    position: 4,
+  },
+  {
+    value: MKT_CUSTOMER_STATUS.OTHER,
+    label: 'Other',
+    color: 'gray',
+    position: 5,
+  },
+];
+
+export const MKT_CUSTOMER_TIER_OPTIONS: FieldMetadataComplexOption[] = [
+  {
+    value: MKT_CUSTOMER_TIER.INDIVIDUAL,
+    label: 'Individual',
+    color: 'blue',
+    position: 1,
+  },
+  {
+    value: MKT_CUSTOMER_TIER.SMALL,
+    label: 'Small',
+    color: 'green',
+    position: 2,
+  },
+  {
+    value: MKT_CUSTOMER_TIER.MEDIUM,
+    label: 'Medium',
+    color: 'yellow',
+    position: 3,
+  },
+  {
+    value: MKT_CUSTOMER_TIER.ENTERPRISE,
+    label: 'Enterprise',
+    color: 'red',
+    position: 4,
+  },
+  {
+    value: MKT_CUSTOMER_TIER.OTHER,
+    label: 'Other',
+    color: 'gray',
+    position: 5,
+  },
+];
+
+export const MKT_CUSTOMER_LIFECYCLE_STAGE_OPTIONS: FieldMetadataComplexOption[] =
+  [
+    {
+      value: MKT_CUSTOMER_LIFECYCLE_STAGE.PROSPECTIVE,
+      label: 'Prospective',
+      color: 'yellow',
+      position: 1,
+    },
+    {
+      value: MKT_CUSTOMER_LIFECYCLE_STAGE.TRIAL,
+      label: 'Trial',
+      color: 'green',
+      position: 2,
+    },
+    {
+      value: MKT_CUSTOMER_LIFECYCLE_STAGE.CUSTOMER,
+      label: 'Customer',
+      color: 'red',
+      position: 3,
+    },
+
+    {
+      value: MKT_CUSTOMER_LIFECYCLE_STAGE.LOYAL,
+      label: 'Loyal',
+      color: 'purple',
+      position: 4,
+    },
+    {
+      value: MKT_CUSTOMER_LIFECYCLE_STAGE.CHURNED,
+      label: 'Churned',
+      color: 'gray',
+      position: 5,
+    },
+    {
+      value: MKT_CUSTOMER_LIFECYCLE_STAGE.RETENTION,
+      label: 'Retention',
+      color: 'orange',
+      position: 6,
+    },
+    {
+      value: MKT_CUSTOMER_LIFECYCLE_STAGE.UPSELL,
+      label: 'Upsell',
+      color: 'pink',
+      position: 7,
+    },
+    {
+      value: MKT_CUSTOMER_LIFECYCLE_STAGE.CROSS_SELL,
+      label: 'Cross Sell',
+      color: 'orange',
+      position: 8,
+    },
+    {
+      value: MKT_CUSTOMER_LIFECYCLE_STAGE.REACTIVATION,
+      label: 'Reactivation',
+      color: 'purple',
+      position: 9,
+    },
+  ];
+
+export const MKT_CUSTOMER_TAGS_OPTIONS: FieldMetadataComplexOption[] = [
+  {
+    value: MKT_CUSTOMER_TAGS.NEW,
+    label: 'New',
+    color: 'blue',
+    position: 1,
+  },
+  {
+    value: MKT_CUSTOMER_TAGS.RETURNING,
+    label: 'Returning',
+    color: 'green',
+    position: 2,
+  },
+  {
+    value: MKT_CUSTOMER_TAGS.LOYAL,
+    label: 'Loyal',
+    color: 'purple',
+    position: 3,
+  },
+  {
+    value: MKT_CUSTOMER_TAGS.VIP,
+    label: 'VIP',
+    color: 'pink',
+    position: 4,
+  },
+  {
+    value: MKT_CUSTOMER_TAGS.CHURNED,
+    label: 'Churned',
+    color: 'red',
+    position: 5,
+  },
+  {
+    value: MKT_CUSTOMER_TAGS.RETENTION,
+    label: 'Retention',
+    color: 'orange',
+    position: 6,
+  },
+  {
+    value: MKT_CUSTOMER_TAGS.TECHNICAL,
+    label: 'Technical',
+    color: 'green',
+    position: 7,
+  },
+  {
+    value: MKT_CUSTOMER_TAGS.OTHER,
+    label: 'Other',
+    color: 'gray',
+    position: 8,
+  },
+];

--- a/packages/twenty-server/src/mkt-core/customer/mkt-customer.workspace-entity.ts
+++ b/packages/twenty-server/src/mkt-core/customer/mkt-customer.workspace-entity.ts
@@ -35,6 +35,7 @@ import {
 } from 'src/mkt-core/constants/mkt-customer.constant';
 import { MKT_CUSTOMER_FIELD_IDS } from 'src/mkt-core/constants/mkt-field-ids';
 import { MKT_OBJECT_IDS } from 'src/mkt-core/constants/mkt-object-ids';
+import { MktLicenseWorkspaceEntity } from 'src/mkt-core/license/mkt-license.workspace-entity';
 import { TimelineActivityWorkspaceEntity } from 'src/modules/timeline/standard-objects/timeline-activity.workspace-entity';
 import { WorkspaceMemberWorkspaceEntity } from 'src/modules/workspace-member/standard-objects/workspace-member.workspace-entity';
 
@@ -230,6 +231,19 @@ export class MktCustomerWorkspaceEntity extends BaseWorkspaceEntity {
     description: msg`The creator of the record`,
   })
   createdBy: ActorMetadata;
+
+  @WorkspaceRelation({
+    standardId: MKT_CUSTOMER_FIELD_IDS.mktLicenses,
+    type: RelationType.ONE_TO_MANY,
+    label: msg`Licenses`,
+    description: msg`Licenses of the customer`,
+    icon: 'IconLicense',
+    inverseSideTarget: () => MktLicenseWorkspaceEntity,
+    inverseSideFieldKey: 'mktCustomer',
+    onDelete: RelationOnDeleteAction.SET_NULL,
+  })
+  @WorkspaceIsNullable()
+  mktLicenses: Relation<MktLicenseWorkspaceEntity[]>;
 
   @WorkspaceRelation({
     standardId: MKT_CUSTOMER_FIELD_IDS.accountOwner,

--- a/packages/twenty-server/src/mkt-core/dev-seeder/constants/mkt-license-data-seeds.constants.ts
+++ b/packages/twenty-server/src/mkt-core/dev-seeder/constants/mkt-license-data-seeds.constants.ts
@@ -1,3 +1,4 @@
+import { MKT_CUSTOMER_DATA_SEEDS_IDS } from 'src/mkt-core/dev-seeder/constants/mkt-customer-data-seeds.constants';
 import { MKT_ORDER_DATA_SEEDS_IDS } from 'src/mkt-core/dev-seeder/constants/mkt-order-data-seeds.constants';
 import { MKT_VARIANT_DATA_SEEDS_IDS } from 'src/mkt-core/dev-seeder/constants/mkt-variant-data-seeds.constants';
 
@@ -14,6 +15,7 @@ type MktLicenseDataSeed = {
 
   mktOrderId: string;
   mktVariantId: string;
+  mktCustomerId: string;
 
   position: number;
   createdBySource: string;
@@ -42,6 +44,7 @@ export const MKT_LICENSE_DATA_SEED_COLUMNS: (keyof MktLicenseDataSeed)[] = [
   'notes',
   'mktOrderId',
   'mktVariantId',
+  'mktCustomerId',
   'position',
   'createdBySource',
   'createdByWorkspaceMemberId',
@@ -81,6 +84,7 @@ export const MKT_LICENSE_DATA_SEEDS: MktLicenseDataSeed[] = [
     notes: 'Notes 1',
     mktOrderId: MKT_ORDER_DATA_SEEDS_IDS.ID_1,
     mktVariantId: MKT_VARIANT_DATA_SEEDS_IDS.ID_1,
+    mktCustomerId: MKT_CUSTOMER_DATA_SEEDS_IDS.ID_1,
     position: 1,
     createdBySource: 'API',
     createdByWorkspaceMemberId: null,
@@ -98,6 +102,7 @@ export const MKT_LICENSE_DATA_SEEDS: MktLicenseDataSeed[] = [
     notes: 'Notes 2',
     mktOrderId: MKT_ORDER_DATA_SEEDS_IDS.ID_2,
     mktVariantId: MKT_VARIANT_DATA_SEEDS_IDS.ID_2,
+    mktCustomerId: MKT_CUSTOMER_DATA_SEEDS_IDS.ID_2,
     position: 2,
     createdBySource: 'API',
     createdByWorkspaceMemberId: null,
@@ -115,6 +120,7 @@ export const MKT_LICENSE_DATA_SEEDS: MktLicenseDataSeed[] = [
     notes: 'Notes 3',
     mktOrderId: MKT_ORDER_DATA_SEEDS_IDS.ID_3,
     mktVariantId: MKT_VARIANT_DATA_SEEDS_IDS.ID_3,
+    mktCustomerId: MKT_CUSTOMER_DATA_SEEDS_IDS.ID_3,
     position: 3,
     createdBySource: 'API',
     createdByWorkspaceMemberId: null,
@@ -132,6 +138,7 @@ export const MKT_LICENSE_DATA_SEEDS: MktLicenseDataSeed[] = [
     notes: 'Notes 4',
     mktOrderId: MKT_ORDER_DATA_SEEDS_IDS.ID_4,
     mktVariantId: MKT_VARIANT_DATA_SEEDS_IDS.ID_4,
+    mktCustomerId: MKT_CUSTOMER_DATA_SEEDS_IDS.ID_4,
     position: 4,
     createdBySource: 'API',
     createdByWorkspaceMemberId: null,
@@ -149,6 +156,7 @@ export const MKT_LICENSE_DATA_SEEDS: MktLicenseDataSeed[] = [
     notes: 'Notes 5',
     mktOrderId: MKT_ORDER_DATA_SEEDS_IDS.ID_5,
     mktVariantId: MKT_VARIANT_DATA_SEEDS_IDS.ID_5,
+    mktCustomerId: MKT_CUSTOMER_DATA_SEEDS_IDS.ID_5,
     position: 5,
     createdBySource: 'API',
     createdByWorkspaceMemberId: null,
@@ -166,6 +174,7 @@ export const MKT_LICENSE_DATA_SEEDS: MktLicenseDataSeed[] = [
     notes: 'Notes 6',
     mktOrderId: MKT_ORDER_DATA_SEEDS_IDS.ID_1,
     mktVariantId: MKT_VARIANT_DATA_SEEDS_IDS.ID_6,
+    mktCustomerId: MKT_CUSTOMER_DATA_SEEDS_IDS.ID_6,
     position: 6,
     createdBySource: 'API',
     createdByWorkspaceMemberId: null,
@@ -183,6 +192,7 @@ export const MKT_LICENSE_DATA_SEEDS: MktLicenseDataSeed[] = [
     notes: 'Notes 7',
     mktOrderId: MKT_ORDER_DATA_SEEDS_IDS.ID_2,
     mktVariantId: MKT_VARIANT_DATA_SEEDS_IDS.ID_7,
+    mktCustomerId: MKT_CUSTOMER_DATA_SEEDS_IDS.ID_7,
     position: 7,
     createdBySource: 'API',
     createdByWorkspaceMemberId: null,
@@ -200,6 +210,7 @@ export const MKT_LICENSE_DATA_SEEDS: MktLicenseDataSeed[] = [
     notes: 'Notes 8',
     mktOrderId: MKT_ORDER_DATA_SEEDS_IDS.ID_3,
     mktVariantId: MKT_VARIANT_DATA_SEEDS_IDS.ID_8,
+    mktCustomerId: MKT_CUSTOMER_DATA_SEEDS_IDS.ID_8,
     position: 8,
     createdBySource: 'API',
     createdByWorkspaceMemberId: null,
@@ -217,6 +228,7 @@ export const MKT_LICENSE_DATA_SEEDS: MktLicenseDataSeed[] = [
     notes: 'Notes 9',
     mktOrderId: MKT_ORDER_DATA_SEEDS_IDS.ID_4,
     mktVariantId: MKT_VARIANT_DATA_SEEDS_IDS.ID_9,
+    mktCustomerId: MKT_CUSTOMER_DATA_SEEDS_IDS.ID_9,
     position: 9,
     createdBySource: 'API',
     createdByWorkspaceMemberId: null,
@@ -234,6 +246,7 @@ export const MKT_LICENSE_DATA_SEEDS: MktLicenseDataSeed[] = [
     notes: 'Notes 10',
     mktOrderId: MKT_ORDER_DATA_SEEDS_IDS.ID_5,
     mktVariantId: MKT_VARIANT_DATA_SEEDS_IDS.ID_10,
+    mktCustomerId: MKT_CUSTOMER_DATA_SEEDS_IDS.ID_10,
     position: 10,
     createdBySource: 'API',
     createdByWorkspaceMemberId: null,
@@ -251,6 +264,7 @@ export const MKT_LICENSE_DATA_SEEDS: MktLicenseDataSeed[] = [
     notes: 'Notes 11',
     mktOrderId: MKT_ORDER_DATA_SEEDS_IDS.ID_6,
     mktVariantId: MKT_VARIANT_DATA_SEEDS_IDS.ID_11,
+    mktCustomerId: MKT_CUSTOMER_DATA_SEEDS_IDS.ID_11,
     position: 11,
     createdBySource: 'API',
     createdByWorkspaceMemberId: null,
@@ -268,6 +282,7 @@ export const MKT_LICENSE_DATA_SEEDS: MktLicenseDataSeed[] = [
     notes: 'Notes 12',
     mktOrderId: MKT_ORDER_DATA_SEEDS_IDS.ID_7,
     mktVariantId: MKT_VARIANT_DATA_SEEDS_IDS.MKT_CARE_BASIC_6_MONTHS_ID,
+    mktCustomerId: MKT_CUSTOMER_DATA_SEEDS_IDS.ID_12,
     position: 12,
     createdBySource: 'API',
     createdByWorkspaceMemberId: null,
@@ -285,6 +300,7 @@ export const MKT_LICENSE_DATA_SEEDS: MktLicenseDataSeed[] = [
     notes: 'Notes 13',
     mktOrderId: MKT_ORDER_DATA_SEEDS_IDS.ID_8,
     mktVariantId: MKT_VARIANT_DATA_SEEDS_IDS.MKT_CARE_BASIC_12_MONTHS_ID,
+    mktCustomerId: MKT_CUSTOMER_DATA_SEEDS_IDS.ID_13,
     position: 13,
     createdBySource: 'API',
     createdByWorkspaceMemberId: null,
@@ -302,6 +318,7 @@ export const MKT_LICENSE_DATA_SEEDS: MktLicenseDataSeed[] = [
     notes: 'Notes 14',
     mktOrderId: MKT_ORDER_DATA_SEEDS_IDS.ID_9,
     mktVariantId: MKT_VARIANT_DATA_SEEDS_IDS.MKT_CARE_PREMIUM_12_MONTHS_ID,
+    mktCustomerId: MKT_CUSTOMER_DATA_SEEDS_IDS.ID_14,
     position: 14,
     createdBySource: 'API',
     createdByWorkspaceMemberId: null,
@@ -319,6 +336,7 @@ export const MKT_LICENSE_DATA_SEEDS: MktLicenseDataSeed[] = [
     notes: 'Notes 15',
     mktOrderId: MKT_ORDER_DATA_SEEDS_IDS.ID_10,
     mktVariantId: MKT_VARIANT_DATA_SEEDS_IDS.MKT_EMAIL_PLUS_VN_ID,
+    mktCustomerId: MKT_CUSTOMER_DATA_SEEDS_IDS.ID_15,
     position: 15,
     createdBySource: 'API',
     createdByWorkspaceMemberId: null,

--- a/packages/twenty-server/src/mkt-core/license/mkt-license.workspace-entity.ts
+++ b/packages/twenty-server/src/mkt-core/license/mkt-license.workspace-entity.ts
@@ -25,6 +25,7 @@ import {
 } from 'src/engine/workspace-manager/workspace-sync-metadata/utils/get-ts-vector-column-expression.util';
 import { MKT_LICENSE_FIELD_IDS } from 'src/mkt-core/constants/mkt-field-ids';
 import { MKT_OBJECT_IDS } from 'src/mkt-core/constants/mkt-object-ids';
+import { MktCustomerWorkspaceEntity } from 'src/mkt-core/customer/mkt-customer.workspace-entity';
 import { MktOrderWorkspaceEntity } from 'src/mkt-core/order/mkt-order.workspace-entity';
 import { MktVariantWorkspaceEntity } from 'src/mkt-core/variant/mkt-variant.workspace-entity';
 import { TimelineActivityWorkspaceEntity } from 'src/modules/timeline/standard-objects/timeline-activity.workspace-entity';
@@ -187,6 +188,22 @@ export class MktLicenseWorkspaceEntity extends BaseWorkspaceEntity {
 
   @WorkspaceJoinColumn('mktVariant')
   mktVariantId: string | null;
+
+  @WorkspaceRelation({
+    standardId: MKT_LICENSE_FIELD_IDS.mktCustomer,
+    type: RelationType.MANY_TO_ONE,
+    label: msg`Customer`,
+    description: msg`License customer`,
+    icon: 'IconUser',
+    inverseSideTarget: () => MktCustomerWorkspaceEntity,
+    inverseSideFieldKey: 'mktLicenses',
+    onDelete: RelationOnDeleteAction.SET_NULL,
+  })
+  @WorkspaceIsNullable()
+  mktCustomer: Relation<MktCustomerWorkspaceEntity> | null;
+
+  @WorkspaceJoinColumn('mktCustomer')
+  mktCustomerId: string | null;
 
   @WorkspaceRelation({
     standardId: MKT_LICENSE_FIELD_IDS.mktOrder,


### PR DESCRIPTION
…and data fields

- Added mktLicenses field to MktCustomerWorkspaceEntity to establish a one-to-many relationship with licenses.
- Introduced mktCustomer field in MktLicenseWorkspaceEntity for a many-to-one relationship with customers.
- Updated MKT_LICENSE_DATA_SEEDS to include mktCustomerId for better data association in license records.
- Improved data seeding structure to ensure consistency with new entity definitions.