### PR TITLE
refactor: comment out WorkspaceIsSearchable decorator in multiple inv…

### DIFF
--- a/packages/twenty-server/src/mkt-core/invoice/objects/mkt-invoice.workspace-entity.ts
+++ b/packages/twenty-server/src/mkt-core/invoice/objects/mkt-invoice.workspace-entity.ts
@@ -15,7 +15,6 @@ import { WorkspaceEntity } from 'src/engine/twenty-orm/decorators/workspace-enti
 import { WorkspaceFieldIndex } from 'src/engine/twenty-orm/decorators/workspace-field-index.decorator';
 import { WorkspaceField } from 'src/engine/twenty-orm/decorators/workspace-field.decorator';
 import { WorkspaceIsNullable } from 'src/engine/twenty-orm/decorators/workspace-is-nullable.decorator';
-import { WorkspaceIsSearchable } from 'src/engine/twenty-orm/decorators/workspace-is-searchable.decorator';
 import { WorkspaceIsSystem } from 'src/engine/twenty-orm/decorators/workspace-is-system.decorator';
 import { WorkspaceJoinColumn } from 'src/engine/twenty-orm/decorators/workspace-join-column.decorator';
 import { WorkspaceRelation } from 'src/engine/twenty-orm/decorators/workspace-relation.decorator';
@@ -83,7 +82,7 @@ export const MKT_INVOICE_STATUS_OPTIONS: FieldMetadataComplexOption[] = [
   labelIdentifierStandardId: MKT_INVOICE_FIELD_IDS.name,
 })
 @WorkspaceDuplicateCriteria([['name'], ['sInvoiceCode']])
-@WorkspaceIsSearchable()
+//@WorkspaceIsSearchable()
 export class MktInvoiceWorkspaceEntity extends BaseWorkspaceEntity {
   @WorkspaceField({
     standardId: MKT_INVOICE_FIELD_IDS.name,

--- a/packages/twenty-server/src/mkt-core/invoice/objects/mkt-sinvoice-file.workspace-entity.ts
+++ b/packages/twenty-server/src/mkt-core/invoice/objects/mkt-sinvoice-file.workspace-entity.ts
@@ -14,7 +14,6 @@ import { WorkspaceEntity } from 'src/engine/twenty-orm/decorators/workspace-enti
 import { WorkspaceFieldIndex } from 'src/engine/twenty-orm/decorators/workspace-field-index.decorator';
 import { WorkspaceField } from 'src/engine/twenty-orm/decorators/workspace-field.decorator';
 import { WorkspaceIsNullable } from 'src/engine/twenty-orm/decorators/workspace-is-nullable.decorator';
-import { WorkspaceIsSearchable } from 'src/engine/twenty-orm/decorators/workspace-is-searchable.decorator';
 import { WorkspaceIsSystem } from 'src/engine/twenty-orm/decorators/workspace-is-system.decorator';
 import { WorkspaceJoinColumn } from 'src/engine/twenty-orm/decorators/workspace-join-column.decorator';
 import { WorkspaceRelation } from 'src/engine/twenty-orm/decorators/workspace-relation.decorator';
@@ -52,7 +51,7 @@ export const SEARCH_FIELDS_FOR_MKT_SINVOICE_FILE: FieldTypeAndNameMetadata[] = [
   labelIdentifierStandardId: MKT_SINVOICE_FILE_FIELD_IDS.name,
 })
 @WorkspaceDuplicateCriteria([['name'], ['fileName']])
-@WorkspaceIsSearchable()
+//@WorkspaceIsSearchable()
 export class MktSInvoiceFileWorkspaceEntity extends BaseWorkspaceEntity {
   @WorkspaceField({
     standardId: MKT_SINVOICE_FILE_FIELD_IDS.name,

--- a/packages/twenty-server/src/mkt-core/invoice/objects/mkt-sinvoice-item.workspace-entity.ts
+++ b/packages/twenty-server/src/mkt-core/invoice/objects/mkt-sinvoice-item.workspace-entity.ts
@@ -14,7 +14,6 @@ import { WorkspaceEntity } from 'src/engine/twenty-orm/decorators/workspace-enti
 import { WorkspaceFieldIndex } from 'src/engine/twenty-orm/decorators/workspace-field-index.decorator';
 import { WorkspaceField } from 'src/engine/twenty-orm/decorators/workspace-field.decorator';
 import { WorkspaceIsNullable } from 'src/engine/twenty-orm/decorators/workspace-is-nullable.decorator';
-import { WorkspaceIsSearchable } from 'src/engine/twenty-orm/decorators/workspace-is-searchable.decorator';
 import { WorkspaceIsSystem } from 'src/engine/twenty-orm/decorators/workspace-is-system.decorator';
 import { WorkspaceJoinColumn } from 'src/engine/twenty-orm/decorators/workspace-join-column.decorator';
 import { WorkspaceRelation } from 'src/engine/twenty-orm/decorators/workspace-relation.decorator';
@@ -45,7 +44,7 @@ export const SEARCH_FIELDS_FOR_MKT_SINVOICE_ITEM: FieldTypeAndNameMetadata[] = [
   labelIdentifierStandardId: MKT_SINVOICE_ITEM_FIELD_IDS.name,
 })
 @WorkspaceDuplicateCriteria([['name'], ['lineNumber']])
-@WorkspaceIsSearchable()
+//@WorkspaceIsSearchable()
 export class MktSInvoiceItemWorkspaceEntity extends BaseWorkspaceEntity {
   @WorkspaceField({
     standardId: MKT_SINVOICE_ITEM_FIELD_IDS.name,

--- a/packages/twenty-server/src/mkt-core/invoice/objects/mkt-sinvoice-metadata.workspace-entity.ts
+++ b/packages/twenty-server/src/mkt-core/invoice/objects/mkt-sinvoice-metadata.workspace-entity.ts
@@ -14,7 +14,6 @@ import { WorkspaceEntity } from 'src/engine/twenty-orm/decorators/workspace-enti
 import { WorkspaceFieldIndex } from 'src/engine/twenty-orm/decorators/workspace-field-index.decorator';
 import { WorkspaceField } from 'src/engine/twenty-orm/decorators/workspace-field.decorator';
 import { WorkspaceIsNullable } from 'src/engine/twenty-orm/decorators/workspace-is-nullable.decorator';
-import { WorkspaceIsSearchable } from 'src/engine/twenty-orm/decorators/workspace-is-searchable.decorator';
 import { WorkspaceIsSystem } from 'src/engine/twenty-orm/decorators/workspace-is-system.decorator';
 import { WorkspaceJoinColumn } from 'src/engine/twenty-orm/decorators/workspace-join-column.decorator';
 import { WorkspaceRelation } from 'src/engine/twenty-orm/decorators/workspace-relation.decorator';
@@ -44,7 +43,7 @@ export const SEARCH_FIELDS_FOR_MKT_SINVOICE_METADATA: FieldTypeAndNameMetadata[]
   labelIdentifierStandardId: MKT_SINVOICE_METADATA_FIELD_IDS.name,
 })
 @WorkspaceDuplicateCriteria([['name']])
-@WorkspaceIsSearchable()
+//@WorkspaceIsSearchable()
 export class MktSInvoiceMetadataWorkspaceEntity extends BaseWorkspaceEntity {
   @WorkspaceField({
     standardId: MKT_SINVOICE_METADATA_FIELD_IDS.name,

--- a/packages/twenty-server/src/mkt-core/invoice/objects/mkt-sinvoice-payment.workspace-entity.ts
+++ b/packages/twenty-server/src/mkt-core/invoice/objects/mkt-sinvoice-payment.workspace-entity.ts
@@ -14,7 +14,6 @@ import { WorkspaceEntity } from 'src/engine/twenty-orm/decorators/workspace-enti
 import { WorkspaceFieldIndex } from 'src/engine/twenty-orm/decorators/workspace-field-index.decorator';
 import { WorkspaceField } from 'src/engine/twenty-orm/decorators/workspace-field.decorator';
 import { WorkspaceIsNullable } from 'src/engine/twenty-orm/decorators/workspace-is-nullable.decorator';
-import { WorkspaceIsSearchable } from 'src/engine/twenty-orm/decorators/workspace-is-searchable.decorator';
 import { WorkspaceIsSystem } from 'src/engine/twenty-orm/decorators/workspace-is-system.decorator';
 import { WorkspaceJoinColumn } from 'src/engine/twenty-orm/decorators/workspace-join-column.decorator';
 import { WorkspaceRelation } from 'src/engine/twenty-orm/decorators/workspace-relation.decorator';
@@ -44,7 +43,7 @@ export const SEARCH_FIELDS_FOR_MKT_SINVOICE_PAYMENT: FieldTypeAndNameMetadata[] 
   labelIdentifierStandardId: MKT_SINVOICE_PAYMENT_FIELD_IDS.name,
 })
 @WorkspaceDuplicateCriteria([['name'], ['licenseKey']])
-@WorkspaceIsSearchable()
+//@WorkspaceIsSearchable()
 export class MktSInvoicePaymentWorkspaceEntity extends BaseWorkspaceEntity {
   @WorkspaceField({
     standardId: MKT_SINVOICE_PAYMENT_FIELD_IDS.name,

--- a/packages/twenty-server/src/mkt-core/invoice/objects/mkt-sinvoice-tax-breakdown.workspace-entity.ts
+++ b/packages/twenty-server/src/mkt-core/invoice/objects/mkt-sinvoice-tax-breakdown.workspace-entity.ts
@@ -14,7 +14,6 @@ import { WorkspaceEntity } from 'src/engine/twenty-orm/decorators/workspace-enti
 import { WorkspaceFieldIndex } from 'src/engine/twenty-orm/decorators/workspace-field-index.decorator';
 import { WorkspaceField } from 'src/engine/twenty-orm/decorators/workspace-field.decorator';
 import { WorkspaceIsNullable } from 'src/engine/twenty-orm/decorators/workspace-is-nullable.decorator';
-import { WorkspaceIsSearchable } from 'src/engine/twenty-orm/decorators/workspace-is-searchable.decorator';
 import { WorkspaceIsSystem } from 'src/engine/twenty-orm/decorators/workspace-is-system.decorator';
 import { WorkspaceJoinColumn } from 'src/engine/twenty-orm/decorators/workspace-join-column.decorator';
 import { WorkspaceRelation } from 'src/engine/twenty-orm/decorators/workspace-relation.decorator';
@@ -44,7 +43,7 @@ export const SEARCH_FIELDS_FOR_MKT_SINVOICE_TAX_BREAKDOWN: FieldTypeAndNameMetad
   labelIdentifierStandardId: MKT_SINVOICE_TAX_BREAKDOWN_FIELD_IDS.name,
 })
 @WorkspaceDuplicateCriteria([['name']])
-@WorkspaceIsSearchable()
+//@WorkspaceIsSearchable()
 export class MktSInvoiceTaxBreakdownWorkspaceEntity extends BaseWorkspaceEntity {
   @WorkspaceField({
     standardId: MKT_SINVOICE_TAX_BREAKDOWN_FIELD_IDS.name,

--- a/packages/twenty-server/src/mkt-core/order/objects/mkt-order.workspace-entity.ts
+++ b/packages/twenty-server/src/mkt-core/order/objects/mkt-order.workspace-entity.ts
@@ -155,7 +155,7 @@ export class MktOrderWorkspaceEntity extends BaseWorkspaceEntity {
     label: msg`SInvoice Status`,
     description: msg`Status of the SInvoice`,
     options: SINVOICE_STATUS_OPTIONS,
-    defaultValue: SINVOICE_STATUS.PENDING,
+    //defaultValue: SINVOICE_STATUS.PENDING,
   })
   @WorkspaceIsNullable()
   sInvoiceStatus?: SINVOICE_STATUS;


### PR DESCRIPTION
…oice-related entities

- Removed the WorkspaceIsSearchable decorator from MktInvoiceWorkspaceEntity, MktSInvoiceFileWorkspaceEntity, MktSInvoiceItemWorkspaceEntity, MktSInvoiceMetadataWorkspaceEntity, MktSInvoicePaymentWorkspaceEntity, and MktSInvoiceTaxBreakdownWorkspaceEntity to streamline search functionality.
- Commented out the default value for sInvoiceStatus in MktOrderWorkspaceEntity to prevent unintended behavior.