### PR TITLE
feat: add seeder for marketing report module and related utilities

### DIFF
--- a/packages/twenty-server/.env.example
+++ b/packages/twenty-server/.env.example
@@ -111,3 +111,9 @@ EMAIL_SMTP_PASSWORD=example
 # ANALYTICS_ENABLED=
 # CLICKHOUSE_URL=http://default:clickhousePassword@localhost:8123/twenty
 # ORDER_OPTIMISTIC_LOCKING_ENABLED='true'
+
+# License Dashboard Stats Cron Configuration
+# Cron pattern for license dashboard stats generation (default: daily at 2:00 AM)
+MKT_LICENSE_STATS_CRON_PATTERN='0 2 * * *'
+# Comma-separated list of workspace IDs for license stats generation
+MKT_LICENSE_STATS_WORKSPACE_IDS='workspace-id-1,workspace-id-2'

--- a/packages/twenty-server/src/mkt-core/constants/mkt-field-ids.ts
+++ b/packages/twenty-server/src/mkt-core/constants/mkt-field-ids.ts
@@ -338,6 +338,22 @@ export const MKT_ORDER_ITEM_FIELD_IDS = {
   searchVector: 'b4c5d6e7-f890-1234-2345-678901234567',
 };
 
+export const MKT_REPORT_FIELD_IDS = {
+  // fields
+  name: 'd2dd1dd1-b45a-405d-8472-0a4f95bc50c0',
+  reportType: '09372938-8d76-44f2-80de-639e5f32ec5b',
+  metadata: 'bf5018be-7211-4096-b9fb-0aaa11f8cd2a',
+  notes: 'c269b8a5-735a-4a16-b36f-d3b7ffd85c71',
+
+  // relations
+  // common relations or fields
+  position: '8b8aeecc-bf80-4af9-a32a-a0c3100f42ab',
+  createdBy: 'baa0cdb1-f773-446b-a3f2-023c0b563738',
+  accountOwner: 'de4f5552-74c6-45f7-a76e-e8244654ce84',
+  timelineActivities: 'ea1ba646-b085-4826-83ac-9a457f219f17',
+  searchVector: '7d4aa9e8-af86-42fe-9ac8-d7f16fa1f00f',
+};
+
 export const MKT_LICENSE_FIELD_IDS = {
   // fields
   name: 'e19495b8-a787-4533-b9fb-e9ff272a04a8',
@@ -695,6 +711,7 @@ export const MKT_PAYMENT_METHOD_FIELD_IDS = {
 
 //EXTENDS FROM TIMELINE_ACTIVITY_STANDARD_FIELD_IDS
 export const TIMELINE_ACTIVITY_MKT_FIELD_IDS = {
+  mktReport: '56bb55c0-59c2-4f68-99c9-4ee1638650dd',
   //i18n
   mktI18n: '70a89432-aeb9-49a3-b263-3b5c57921d78',
   //customers
@@ -761,6 +778,7 @@ export const MKT_KPI_TEMPLATE_HISTORY_FIELD_IDS = {
 
 //EXTENDS FROM WORKSPACE_MEMBER_STANDARD_FIELD_IDS
 export const WORKSPACE_MEMBER_MKT_FIELD_IDS = {
+  accountOwnerForMktReports: 'a55048e3-30c5-4a74-a5e0-70c41b159c00',
   //i18n
   accountOwnerForI18ns: '62b34ddc-a703-4172-ad5c-29c7bb7aa681',
   //customers

--- a/packages/twenty-server/src/mkt-core/constants/mkt-object-ids.ts
+++ b/packages/twenty-server/src/mkt-core/constants/mkt-object-ids.ts
@@ -62,6 +62,8 @@ export const MKT_OBJECT_IDS = {
   mktCustomer: '2c720af2-4412-4317-8a48-0acdaf66bc90',
   mktTag: '6d18dfa8-60f7-4057-8b3c-c0a5d7e7c35f',
   mktCustomerTag: '854cfe1c-9c77-4b71-8248-b5818037a474',
+  //reports
+  mktReport: 'b8acdd19-4852-415a-a783-83bd1231381c',
   //user
   mktUser: '3f9d2c8e-6a41-4c3d-9b71-12a8f53e7b29',
 };

--- a/packages/twenty-server/src/mkt-core/dev-seeder/constants/mkt-license-data-seeds.constants.ts
+++ b/packages/twenty-server/src/mkt-core/dev-seeder/constants/mkt-license-data-seeds.constants.ts
@@ -81,7 +81,112 @@ export const MKT_LICENSE_DATA_SEEDS_IDS = {
   ID_15: '0945f961-de47-4e33-aa67-5a4257b54874',
   ID_16: '8b7f4a9e-1234-4567-8901-234567890abc',
   ID_17: '9c8e7d6b-2345-5678-9012-345678901bcd',
+  // Thêm data để test các trường hợp cụ thể
+  ID_18: 'ccc02145-9907-42c2-8527-d2af338f461a',
+  ID_19: '694e6cc8-af6c-4e25-a923-8cf1b8f882cc',
+  ID_20: '84d4fde8-2fdc-43ff-b361-b0e3c87d0565',
+  ID_21: '201fd3e9-9dec-43e2-bd70-bc7a9b64d58c',
+  ID_22: '22763cd9-5420-4b20-a3b6-5bf2ceabc0cf',
+  ID_23: '390d6a42-3f0d-4493-9c60-f9b4b831616a',
+  ID_24: 'b5eaefbb-1281-4dfb-99c0-57b4bb90b629',
+  ID_25: 'dfee05ef-8599-461b-a05f-3b7a3f1560d1',
+  ID_26: '0eb6628f-84b3-4423-8396-5bcb221d53fc',
+  ID_27: '2712bfd5-4e6e-40a5-83bc-9179a1b65461',
+  ID_28: 'f39f546e-3480-411e-a48b-d5e11a3adf33',
+  ID_29: '4f4f2c41-ac02-485d-856c-d9c7141943e4',
+  ID_30: 'd6deacb9-fa26-4502-b647-b199282c2168',
+  ID_31: '8ac35703-3927-4eb4-a467-fb3aef2eea26',
+  ID_32: 'af419acf-8c41-4406-b84f-266df284e9cb',
+  ID_33: 'b3e57071-021d-4326-8632-204b78b90aa3',
+  ID_34: 'bd2a7c1d-893a-4e48-86ec-aa930df27025',
+  ID_35: '2bf1c429-7df4-4d4e-b90d-4e26c733e481',
+  
+  // ============= THÊM ID CHO DATA TEST MỚI =============
+  // Tháng trước (tháng 9/2025)
+  ID_36: '74cb3b24-007f-4d37-b44f-d115e2c0545b',	
+  ID_37: '2d7b098e-60a7-4193-8d48-59e356297920',	
+  ID_38: '27167c20-5116-4a70-a4f7-6148c81ed07d',	
+  ID_39: '362bd25d-6bcb-4988-b335-165fd91b43d6',	
+  ID_40: 'f7d7d4cd-bf0d-43a4-bde0-17774709f042',	
+  
+  // Hoạt động hôm qua (7/10/2025)
+  ID_41: 'b2a7d8ea-98cd-441b-834b-2db7486d87ec',      
+  ID_42: 'b1054e40-0c3a-4a92-a6e5-d6a763332085',      
+  ID_43: 'b4b8270d-8937-461c-a22f-3d35f16f6504',      
+  
+  // Dùng thử tháng trước
+  ID_44: '3644e529-1857-4e33-a2fb-e697b46ef8dc',      
+  ID_45: '7cd21033-c93a-4135-9dd6-e6c0a3b56791',     
+  
+  // Hết hạn tháng trước
+  ID_46: 'f168de00-0c5c-4085-a5fd-c1dd0e5bb606',      
+  ID_47: '1045172c-7db4-4001-91e3-fcb16c05d0b1',      
+  ID_48: '3ed4d320-2a39-4eef-8d27-79a6010c376c',  
+  
+  // Hoàn tiền tháng trước
+  ID_49: '5bbdb0ba-8a5a-4b22-99aa-9e3b97f6ce41',      
+  ID_50: '31827c05-2eac-4983-b5de-9696245f0a5f',   
 };
+
+/*
+ * ============= MKT LICENSE DATA SEEDS FOR TESTING =============
+ *
+ * Data này được thiết kế để test các trường hợp sau:
+ *
+ * 1. TỔNG BẢN QUYỀN:
+ *    - ID_1 đến ID_50: Tổng 50 licenses
+ *    - Tháng này (10/2025): 35 licenses (ID_1 đến ID_35)
+ *    - Tháng trước (9/2025): 15 licenses (ID_36 đến ID_50)
+ *    - Bao gồm tất cả trạng thái: ACTIVE, EXPIRED, ERROR, REFUND, RENEWING
+ *
+ * 2. ĐANG HOẠT ĐỘNG - ĐĂNG NHẬP HÔM NAY (2025-10-09):
+ *    - ID_18, ID_19, ID_20, ID_32: lastLoginAt = 2025-10-09 (hôm nay)
+ *    - ID_29, ID_30, ID_34, ID_35: Các license mới và đăng nhập gần đây
+ *    - ID_41, ID_42, ID_43: Đăng nhập hôm qua (2025-10-08)
+ *    - ID_37, ID_39: Hoạt động tháng trước
+ *
+ * 3. SỐ BẢN QUYỀN DÙNG THỬ:
+ *    - Tháng này: ID_29 (trial 7 ngày còn hoạt động), ID_30 (trial 14 ngày còn hoạt động), ID_31 (đã hết hạn)
+ *    - Tháng trước: ID_44 (trial tháng 9 đã hết hạn), ID_45 (trial tháng 9 còn hoạt động)
+ *
+ * 4. BẢN QUYỀN HẾT HẠN:
+ *    - Tháng này: ID_21 (hết hạn 9/2024), ID_22 (hết hạn 10/2024), ID_23 (hết hạn 8/2024), ID_31 (trial hết hạn 22/9/2025)
+ *    - Tháng trước: ID_46 (hết hạn 15/9/2025), ID_47 (hết hạn 20/9/2025), ID_48 (hết hạn 25/9/2025)
+ *
+ * 5. ĐÃ HOÀN TIỀN:
+ *    - Tháng này: ID_26 ($299 tháng 9/2024), ID_27 ($599 tháng 10/2024)
+ *    - Tháng trước: ID_49 ($399 tháng 9/2025), ID_50 ($199 tháng 9/2025)
+ *    - status = REFUND để theo dõi số tiền hoàn
+ *
+ * 6. LICENSES SẮP HẾT HẠN (7 ngày tới):
+ *    - ID_24: Hết hạn 11/10/2025 (3 ngày nữa)
+ *    - ID_25: Hết hạn 13/10/2025 (5 ngày nữa)
+ *
+ * 7. TÌNH HÌNH SỬ DỤNG:
+ *    - ID_32: Heavy user (đăng nhập hàng ngày)
+ *    - ID_33: Light user (lâu không đăng nhập)
+ *    - ID_28: Đang gia hạn (RENEWING status)
+ *
+ * 8. LICENSES MỚI (tháng này):
+ *    - ID_34: Tạo ngày 5/10/2025
+ *    - ID_35: Tạo ngày 7/10/2025
+ *
+ * 9. DATA THÁNG TRƯỚC (THÁNG 9/2025):
+ *    - ID_36 đến ID_40: Licenses tạo tháng 9/2025 (5 licenses)
+ *    - ID_41 đến ID_43: Hoạt động hôm qua 8/10/2025 (3 licenses)
+ *    - ID_44 đến ID_45: Trial tháng trước (2 licenses)
+ *    - ID_46 đến ID_48: Hết hạn tháng 9/2025 (3 licenses)
+ *    - ID_49 đến ID_50: Hoàn tiền tháng 9/2025 (2 licenses)
+ *
+ * ============= TỔNG KẾT SỐ LIỆU DASHBOARD =============
+ *
+ * 📊 TỔNG BẢN QUYỀN: 50 licenses (35 tháng này + 15 tháng trước)
+ * 🟢 ĐANG HOẠT ĐỘNG HÔM NAY (9/10): 8 licenses (ID_18,19,20,29,30,32,34,35)
+ * 🟡 HOẠT ĐỘNG HÔM QUA (8/10): 3 licenses (ID_41,42,43)
+ * 🔄 SỐ BẢN QUYỀN DÙNG THỬ: 3 tháng này + 2 tháng trước = 5 total
+ * ❌ BẢN QUYỀN HẾT HẠN: 4 tháng này + 3 tháng trước = 7 total
+ * 💰 ĐÃ HOÀN TIỀN: $898 tháng này + $598 tháng trước = $1496 total
+ */
 
 // prettier-ignore
 export const MKT_LICENSE_DATA_SEEDS: MktLicenseDataSeed[] = [
@@ -390,5 +495,629 @@ export const MKT_LICENSE_DATA_SEEDS: MktLicenseDataSeed[] = [
     createdBySource: 'API',
     createdByWorkspaceMemberId: null,
     createdByName: 'John Doe',
+  },
+
+  // ============= DATA TEST CHO CÁC TRƯỜNG HỢP ĐẶC BIỆT =============
+  
+  // 1. LICENSES ĐANG HOẠT ĐỘNG - ĐĂNG NHẬP HÔM NAY (2025-10-08)
+  {
+    id: MKT_LICENSE_DATA_SEEDS_IDS.ID_18,
+    name: 'License MKT Care Basic 1 năm - Đăng nhập hôm nay',
+    licenseKey: 'MKT-CARE-TODAY-2025-001-abc123',
+    status: MKT_LICENSE_STATUS.ACTIVE,
+    activatedAt: new Date('2024-10-08T00:00:00.000Z'),
+    expiresAt: new Date('2025-12-31T23:59:59.000Z'),
+    lastLoginAt: new Date('2025-10-09T09:15:00.000Z'), // Đăng nhập hôm nay
+    deviceInfo: 'Windows 11 - Chrome Browser - IP: 192.168.1.101',
+    notes: 'License active - đăng nhập hôm nay',
+    mktOrderId: MKT_ORDER_DATA_SEEDS_IDS.ID_1,
+    mktVariantId: MKT_VARIANT_DATA_SEEDS_IDS.MKT_CARE_BASIC_1_YEAR,
+    mktCustomerId: MKT_CUSTOMER_DATA_SEEDS_IDS.ID_1,
+    position: 18,
+    createdBySource: 'API',
+    createdByWorkspaceMemberId: null,
+    createdByName: 'Active User 1',
+  },
+  {
+    id: MKT_LICENSE_DATA_SEEDS_IDS.ID_19,
+    name: 'License MKT Viral Basic - Đăng nhập hôm nay',
+    licenseKey: 'MKT-VIRAL-TODAY-2025-002-def456',
+    status: MKT_LICENSE_STATUS.ACTIVE,
+    activatedAt: new Date('2024-08-15T00:00:00.000Z'),
+    expiresAt: new Date('2026-08-15T00:00:00.000Z'),
+    lastLoginAt: new Date('2025-10-09T14:30:00.000Z'), // Đăng nhập hôm nay
+    deviceInfo: 'macOS Ventura - Safari Browser - IP: 10.0.1.55',
+    notes: 'License active - đăng nhập hôm nay',
+    mktOrderId: MKT_ORDER_DATA_SEEDS_IDS.ID_2,
+    mktVariantId: MKT_VARIANT_DATA_SEEDS_IDS.MKT_VIRAL_BASIC_1_YEAR,
+    mktCustomerId: MKT_CUSTOMER_DATA_SEEDS_IDS.ID_2,
+    position: 19,
+    createdBySource: 'API',
+    createdByWorkspaceMemberId: null,
+    createdByName: 'Active User 2',
+  },
+  {
+    id: MKT_LICENSE_DATA_SEEDS_IDS.ID_20,
+    name: 'License MKT Insta Pro - Đăng nhập hôm nay',
+    licenseKey: 'MKT-INSTA-TODAY-2025-003-ghi789',
+    status: MKT_LICENSE_STATUS.ACTIVE,
+    activatedAt: new Date('2025-01-01T00:00:00.000Z'),
+    expiresAt: new Date('2026-01-01T00:00:00.000Z'),
+    lastLoginAt: new Date('2025-10-09T16:45:00.000Z'), // Đăng nhập hôm nay
+    deviceInfo: 'Ubuntu 22.04 - Firefox Browser - IP: 172.16.0.30',
+    notes: 'License active - đăng nhập hôm nay',
+    mktOrderId: MKT_ORDER_DATA_SEEDS_IDS.ID_4,
+    mktVariantId: MKT_VARIANT_DATA_SEEDS_IDS.MKT_INSTA_BASIC_2_YEAR,
+    mktCustomerId: MKT_CUSTOMER_DATA_SEEDS_IDS.ID_4,
+    position: 20,
+    createdBySource: 'API',
+    createdByWorkspaceMemberId: null,
+    createdByName: 'Active User 3',
+  },
+
+  // 2. LICENSES ĐÃ HẾT HẠN
+  {
+    id: MKT_LICENSE_DATA_SEEDS_IDS.ID_21,
+    name: 'License MKT Care Basic - Đã hết hạn tháng trước',
+    licenseKey: 'MKT-CARE-EXP-2024-001-jkl012',
+    status: MKT_LICENSE_STATUS.EXPIRED,
+    activatedAt: new Date('2023-09-01T00:00:00.000Z'),
+    expiresAt: new Date('2024-09-01T00:00:00.000Z'), // Hết hạn tháng 9/2024
+    lastLoginAt: new Date('2024-08-30T10:00:00.000Z'),
+    deviceInfo: 'Windows 10 - Chrome Browser - IP: 192.168.1.120',
+    notes: 'License đã hết hạn từ tháng 9/2024',
+    mktOrderId: MKT_ORDER_DATA_SEEDS_IDS.ID_1,
+    mktVariantId: MKT_VARIANT_DATA_SEEDS_IDS.MKT_CARE_BASIC_1_YEAR,
+    mktCustomerId: MKT_CUSTOMER_DATA_SEEDS_IDS.ID_1,
+    position: 21,
+    createdBySource: 'API',
+    createdByWorkspaceMemberId: null,
+    createdByName: 'Expired User 1',
+  },
+  {
+    id: MKT_LICENSE_DATA_SEEDS_IDS.ID_22,
+    name: 'License MKT Tube Basic - Đã hết hạn gần đây',
+    licenseKey: 'MKT-TUBE-EXP-2024-002-mno345',
+    status: MKT_LICENSE_STATUS.EXPIRED,
+    activatedAt: new Date('2023-10-10T00:00:00.000Z'),
+    expiresAt: new Date('2024-10-10T00:00:00.000Z'), // Mới hết hạn
+    lastLoginAt: new Date('2024-10-09T15:30:00.000Z'),
+    deviceInfo: 'macOS Monterey - Safari Browser - IP: 10.0.2.105',
+    notes: 'License vừa hết hạn ngày 10/10/2024',
+    mktOrderId: MKT_ORDER_DATA_SEEDS_IDS.ID_5,
+    mktVariantId: MKT_VARIANT_DATA_SEEDS_IDS.MKT_TUBE_BASIC_1_YEAR,
+    mktCustomerId: MKT_CUSTOMER_DATA_SEEDS_IDS.ID_5,
+    position: 22,
+    createdBySource: 'API',
+    createdByWorkspaceMemberId: null,
+    createdByName: 'Expired User 2',
+  },
+  {
+    id: MKT_LICENSE_DATA_SEEDS_IDS.ID_23,
+    name: 'License MKT Post Basic - Hết hạn tháng 8',
+    licenseKey: 'MKT-POST-EXP-2024-003-pqr678',
+    status: MKT_LICENSE_STATUS.EXPIRED,
+    activatedAt: new Date('2023-08-15T00:00:00.000Z'),
+    expiresAt: new Date('2024-08-15T00:00:00.000Z'),
+    lastLoginAt: new Date('2024-08-14T12:45:00.000Z'),
+    deviceInfo: 'Android 13 - Chrome Mobile - IP: 192.168.1.205',
+    notes: 'License hết hạn tháng 8/2024',
+    mktOrderId: MKT_ORDER_DATA_SEEDS_IDS.ID_6,
+    mktVariantId: MKT_VARIANT_DATA_SEEDS_IDS.MKT_POST_BASIC_1_YEAR,
+    mktCustomerId: MKT_CUSTOMER_DATA_SEEDS_IDS.ID_6,
+    position: 23,
+    createdBySource: 'API',
+    createdByWorkspaceMemberId: null,
+    createdByName: 'Expired User 3',
+  },
+
+  // 3. LICENSES SẮP HẾT HẠN (trong 7 ngày tới)
+  {
+    id: MKT_LICENSE_DATA_SEEDS_IDS.ID_24,
+    name: 'License MKT Care Pro - Sắp hết hạn 3 ngày nữa',
+    licenseKey: 'MKT-CARE-SOON-2025-001-stu901',
+    status: MKT_LICENSE_STATUS.ACTIVE,
+    activatedAt: new Date('2024-10-12T00:00:00.000Z'),
+    expiresAt: new Date('2025-10-11T23:59:59.000Z'), // Hết hạn 11/10/2025 (3 ngày nữa)
+    lastLoginAt: new Date('2025-10-07T08:20:00.000Z'),
+    deviceInfo: 'Windows 11 - Edge Browser - IP: 192.168.2.80',
+    notes: 'License sắp hết hạn trong 3 ngày',
+    mktOrderId: MKT_ORDER_DATA_SEEDS_IDS.ID_1,
+    mktVariantId: MKT_VARIANT_DATA_SEEDS_IDS.MKT_CARE_BASIC_1_YEAR,
+    mktCustomerId: MKT_CUSTOMER_DATA_SEEDS_IDS.ID_1,
+    position: 24,
+    createdBySource: 'API',
+    createdByWorkspaceMemberId: null,
+    createdByName: 'Soon Expire User 1',
+  },
+  {
+    id: MKT_LICENSE_DATA_SEEDS_IDS.ID_25,
+    name: 'License MKT Maps Pro - Sắp hết hạn 5 ngày nữa',
+    licenseKey: 'MKT-MAPS-SOON-2025-002-vwx234',
+    status: MKT_LICENSE_STATUS.ACTIVE,
+    activatedAt: new Date('2024-10-14T00:00:00.000Z'),
+    expiresAt: new Date('2025-10-13T23:59:59.000Z'), // Hết hạn 13/10/2025 (5 ngày nữa)
+    lastLoginAt: new Date('2025-10-06T11:15:00.000Z'),
+    deviceInfo: 'macOS Sonoma - Chrome Browser - IP: 10.0.3.160',
+    notes: 'License sắp hết hạn trong 5 ngày',
+    mktOrderId: MKT_ORDER_DATA_SEEDS_IDS.ID_11,
+    mktVariantId: MKT_VARIANT_DATA_SEEDS_IDS.MKT_MAPS_BASIC_1_YEAR,
+    mktCustomerId: MKT_CUSTOMER_DATA_SEEDS_IDS.ID_11,
+    position: 25,
+    createdBySource: 'API',
+    createdByWorkspaceMemberId: null,
+    createdByName: 'Soon Expire User 2',
+  },
+
+  // 4. LICENSES ĐÃ HOÀN TIỀN
+  {
+    id: MKT_LICENSE_DATA_SEEDS_IDS.ID_26,
+    name: 'License MKT Viral Pro - Đã hoàn tiền tháng trước',
+    licenseKey: 'MKT-VIRAL-REF-2024-001-yza567',
+    status: MKT_LICENSE_STATUS.REFUND,
+    activatedAt: new Date('2024-08-01T00:00:00.000Z'),
+    expiresAt: new Date('2025-08-01T00:00:00.000Z'),
+    lastLoginAt: new Date('2024-09-15T10:30:00.000Z'),
+    deviceInfo: 'Windows 11 - Chrome Browser - IP: 192.168.3.30',
+    notes: 'License đã hoàn tiền $299 ngày 15/9/2024 - khách không hài lòng',
+    mktOrderId: MKT_ORDER_DATA_SEEDS_IDS.ID_2,
+    mktVariantId: MKT_VARIANT_DATA_SEEDS_IDS.MKT_VIRAL_BASIC_1_YEAR,
+    mktCustomerId: MKT_CUSTOMER_DATA_SEEDS_IDS.ID_2,
+    position: 26,
+    createdBySource: 'API',
+    createdByWorkspaceMemberId: null,
+    createdByName: 'Refund User 1',
+  },
+  {
+    id: MKT_LICENSE_DATA_SEEDS_IDS.ID_27,
+    name: 'License MKT Insta Premium - Hoàn tiền gần đây',
+    licenseKey: 'MKT-INSTA-REF-2024-002-bcd890',
+    status: MKT_LICENSE_STATUS.REFUND,
+    activatedAt: new Date('2024-09-10T00:00:00.000Z'),
+    expiresAt: new Date('2026-09-10T00:00:00.000Z'),
+    lastLoginAt: new Date('2024-10-01T14:20:00.000Z'),
+    deviceInfo: 'macOS Ventura - Safari Browser - IP: 10.0.4.75',
+    notes: 'License hoàn tiền $599 ngày 05/10/2024 - lỗi kỹ thuật',
+    mktOrderId: MKT_ORDER_DATA_SEEDS_IDS.ID_4,
+    mktVariantId: MKT_VARIANT_DATA_SEEDS_IDS.MKT_INSTA_BASIC_2_YEAR,
+    mktCustomerId: MKT_CUSTOMER_DATA_SEEDS_IDS.ID_4,
+    position: 27,
+    createdBySource: 'API',
+    createdByWorkspaceMemberId: null,
+    createdByName: 'Refund User 2',
+  },
+
+  // 5. LICENSES ĐANG GIA HẠN
+  {
+    id: MKT_LICENSE_DATA_SEEDS_IDS.ID_28,
+    name: 'License MKT Care Enterprise - Đang gia hạn',
+    licenseKey: 'MKT-CARE-REN-2024-001-efg123',
+    status: MKT_LICENSE_STATUS.RENEWING,
+    activatedAt: new Date('2023-10-08T00:00:00.000Z'),
+    expiresAt: new Date('2024-10-08T00:00:00.000Z'),
+    lastLoginAt: new Date('2025-10-07T09:45:00.000Z'),
+    deviceInfo: 'Windows 11 - Chrome Browser - IP: 192.168.4.55',
+    notes: 'License đang trong quá trình gia hạn - thanh toán đang xử lý',
+    mktOrderId: MKT_ORDER_DATA_SEEDS_IDS.ID_1,
+    mktVariantId: MKT_VARIANT_DATA_SEEDS_IDS.MKT_CARE_BASIC_1_YEAR,
+    mktCustomerId: MKT_CUSTOMER_DATA_SEEDS_IDS.ID_1,
+    position: 28,
+    createdBySource: 'API',
+    createdByWorkspaceMemberId: null,
+    createdByName: 'Renewing User 1',
+  },
+
+  // 6. LICENSES DÙNG THỬ (thời hạn ngắn)
+  {
+    id: MKT_LICENSE_DATA_SEEDS_IDS.ID_29,
+    name: 'License MKT Care Trial - Dùng thử 7 ngày',
+    licenseKey: 'MKT-CARE-TRIAL-2025-001-hij456',
+    status: MKT_LICENSE_STATUS.TRIAL,
+    activatedAt: new Date('2025-10-05T00:00:00.000Z'),
+    expiresAt: new Date('2025-10-12T23:59:59.000Z'), // 7 ngày dùng thử
+    lastLoginAt: new Date('2025-10-09T07:30:00.000Z'),
+    deviceInfo: 'Windows 10 - Chrome Browser - IP: 192.168.5.100',
+    notes: 'License dùng thử 7 ngày - khách hàng tiềm năng',
+    mktOrderId: MKT_ORDER_DATA_SEEDS_IDS.ID_1,
+    mktVariantId: MKT_VARIANT_DATA_SEEDS_IDS.MKT_CARE_BASIC_1_YEAR,
+    mktCustomerId: MKT_CUSTOMER_DATA_SEEDS_IDS.ID_14,
+    position: 29,
+    createdBySource: 'API',
+    createdByWorkspaceMemberId: null,
+    createdByName: 'Trial User 1',
+  },
+  {
+    id: MKT_LICENSE_DATA_SEEDS_IDS.ID_30,
+    name: 'License MKT Viral Trial - Dùng thử 14 ngày',
+    licenseKey: 'MKT-VIRAL-TRIAL-2025-002-klm789',
+    status: MKT_LICENSE_STATUS.TRIAL,
+    activatedAt: new Date('2025-10-01T00:00:00.000Z'),
+    expiresAt: new Date('2025-10-15T23:59:59.000Z'), // 14 ngày dùng thử
+    lastLoginAt: new Date('2025-10-09T13:20:00.000Z'),
+    deviceInfo: 'macOS Monterey - Safari Browser - IP: 10.0.5.85',
+    notes: 'License dùng thử 14 ngày - startup',
+    mktOrderId: MKT_ORDER_DATA_SEEDS_IDS.ID_2,
+    mktVariantId: MKT_VARIANT_DATA_SEEDS_IDS.MKT_VIRAL_BASIC_1_YEAR,
+    mktCustomerId: MKT_CUSTOMER_DATA_SEEDS_IDS.ID_15,
+    position: 30,
+    createdBySource: 'API',
+    createdByWorkspaceMemberId: null,
+    createdByName: 'Trial User 2',
+  },
+  {
+    id: MKT_LICENSE_DATA_SEEDS_IDS.ID_31,
+    name: 'License MKT Maps Trial - Dùng thử hết hạn',
+    licenseKey: 'MKT-MAPS-TRIAL-2025-003-nop012',
+    status: MKT_LICENSE_STATUS.TRIAL,
+    activatedAt: new Date('2025-09-15T00:00:00.000Z'),
+    expiresAt: new Date('2025-09-22T23:59:59.000Z'), // Dùng thử đã hết hạn
+    lastLoginAt: new Date('2025-09-21T16:45:00.000Z'),
+    deviceInfo: 'Ubuntu 22.04 - Firefox Browser - IP: 172.16.1.50',
+    notes: 'License dùng thử đã hết hạn - chưa chuyển đổi',
+    mktOrderId: MKT_ORDER_DATA_SEEDS_IDS.ID_11,
+    mktVariantId: MKT_VARIANT_DATA_SEEDS_IDS.MKT_MAPS_BASIC_1_YEAR,
+    mktCustomerId: MKT_CUSTOMER_DATA_SEEDS_IDS.ID_12,
+    position: 31,
+    createdBySource: 'API',
+    createdByWorkspaceMemberId: null,
+    createdByName: 'Trial Expired User',
+  },
+
+  // 7. LICENSES CÓ PATTERN SỬ DỤNG KHÁC NHAU
+  {
+    id: MKT_LICENSE_DATA_SEEDS_IDS.ID_32,
+    name: 'License MKT Page Pro - Sử dụng thường xuyên',
+    licenseKey: 'MKT-PAGE-FREQ-2025-001-qrs345',
+    status: MKT_LICENSE_STATUS.ACTIVE,
+    activatedAt: new Date('2024-01-01T00:00:00.000Z'),
+    expiresAt: new Date('2025-12-31T23:59:59.000Z'),
+    lastLoginAt: new Date('2025-10-09T06:00:00.000Z'), // Đăng nhập sớm hôm nay
+    deviceInfo: 'Windows 11 - Chrome Browser - IP: 192.168.6.25',
+    notes: 'User rất tích cực - đăng nhập hàng ngày',
+    mktOrderId: MKT_ORDER_DATA_SEEDS_IDS.ID_10,
+    mktVariantId: MKT_VARIANT_DATA_SEEDS_IDS.MKT_PAGE_BASIC_2_YEAR,
+    mktCustomerId: MKT_CUSTOMER_DATA_SEEDS_IDS.ID_10,
+    position: 32,
+    createdBySource: 'API',
+    createdByWorkspaceMemberId: null,
+    createdByName: 'Heavy User',
+  },
+  {
+    id: MKT_LICENSE_DATA_SEEDS_IDS.ID_33,
+    name: 'License MKT Group Enterprise - Sử dụng ít',
+    licenseKey: 'MKT-GROUP-LOW-2025-002-tuv678',
+    status: MKT_LICENSE_STATUS.ACTIVE,
+    activatedAt: new Date('2024-06-01T00:00:00.000Z'),
+    expiresAt: new Date('2025-11-30T23:59:59.000Z'),
+    lastLoginAt: new Date('2025-09-15T14:30:00.000Z'), // Lâu không đăng nhập
+    deviceInfo: 'macOS Ventura - Safari Browser - IP: 10.0.6.120',
+    notes: 'User ít sử dụng - cần chăm sóc',
+    mktOrderId: MKT_ORDER_DATA_SEEDS_IDS.ID_8,
+    mktVariantId: MKT_VARIANT_DATA_SEEDS_IDS.MKT_GROUP_BASIC_1_YEAR,
+    mktCustomerId: MKT_CUSTOMER_DATA_SEEDS_IDS.ID_8,
+    position: 33,
+    createdBySource: 'API',
+    createdByWorkspaceMemberId: null,
+    createdByName: 'Light User',
+  },
+
+  // 8. LICENSES MỚI ĐƯỢC TẠO (tháng này)
+  {
+    id: MKT_LICENSE_DATA_SEEDS_IDS.ID_34,
+    name: 'License MKT Twitter Premium - Mới tạo tuần này',
+    licenseKey: 'MKT-TWITTER-NEW-2025-001-wxy901',
+    status: MKT_LICENSE_STATUS.ACTIVE,
+    activatedAt: new Date('2025-10-05T00:00:00.000Z'),
+    expiresAt: new Date('2026-10-05T00:00:00.000Z'),
+    lastLoginAt: new Date('2025-10-09T11:30:00.000Z'),
+    deviceInfo: 'Windows 11 - Edge Browser - IP: 192.168.7.45',
+    notes: 'License mới được tạo tuần này',
+    mktOrderId: MKT_ORDER_DATA_SEEDS_IDS.ID_9,
+    mktVariantId: MKT_VARIANT_DATA_SEEDS_IDS.MKT_TWITTER_BASIC_1_YEAR,
+    mktCustomerId: MKT_CUSTOMER_DATA_SEEDS_IDS.ID_9,
+    position: 34,
+    createdBySource: 'API',
+    createdByWorkspaceMemberId: null,
+    createdByName: 'New Customer',
+  },
+  {
+    id: MKT_LICENSE_DATA_SEEDS_IDS.ID_35,
+    name: 'License MKT Zalo Enterprise - Mới kích hoạt',
+    licenseKey: 'MKT-ZALO-NEW-2025-002-zab234',
+    status: MKT_LICENSE_STATUS.ACTIVE,
+    activatedAt: new Date('2025-10-07T00:00:00.000Z'),
+    expiresAt: new Date('2027-10-07T00:00:00.000Z'),
+    lastLoginAt: new Date('2025-10-09T17:15:00.000Z'),
+    deviceInfo: 'iOS 17 - Safari Mobile - IP: 172.20.1.75',
+    notes: 'License mới kích hoạt hôm qua',
+    mktOrderId: MKT_ORDER_DATA_SEEDS_IDS.ID_7,
+    mktVariantId: MKT_VARIANT_DATA_SEEDS_IDS.MKT_ZALO_BASIC_2_YEAR,
+    mktCustomerId: MKT_CUSTOMER_DATA_SEEDS_IDS.ID_7,
+    position: 35,
+    createdBySource: 'API',
+    createdByWorkspaceMemberId: null,
+    createdByName: 'Fresh Customer',
+  },
+
+  // ============= DATA THÁNG TRƯỚC (THÁNG 9/2025) =============
+  
+  // 1. LICENSES TẠO THÁNG 9/2025 - HOẠT ĐỘNG BÌNh THƯỜNG
+  {
+    id: MKT_LICENSE_DATA_SEEDS_IDS.ID_36,
+    name: 'License MKT Care Basic - Tạo đầu tháng 9',
+    licenseKey: 'MKT-CARE-SEP-2025-001-abc111',
+    status: MKT_LICENSE_STATUS.ACTIVE,
+    activatedAt: new Date('2025-09-05T00:00:00.000Z'),
+    expiresAt: new Date('2026-09-05T00:00:00.000Z'),
+    lastLoginAt: new Date('2025-09-25T10:30:00.000Z'),
+    deviceInfo: 'Windows 11 - Chrome Browser - IP: 192.168.1.110',
+    notes: 'License tạo tháng trước - hoạt động bình thường',
+    mktOrderId: MKT_ORDER_DATA_SEEDS_IDS.ID_1,
+    mktVariantId: MKT_VARIANT_DATA_SEEDS_IDS.MKT_CARE_BASIC_1_YEAR,
+    mktCustomerId: MKT_CUSTOMER_DATA_SEEDS_IDS.ID_1,
+    position: 36,
+    createdBySource: 'API',
+    createdByWorkspaceMemberId: null,
+    createdByName: 'September User 1',
+  },
+  {
+    id: MKT_LICENSE_DATA_SEEDS_IDS.ID_37,
+    name: 'License MKT Viral Pro - Tạo giữa tháng 9 - hoạt động tích cực',
+    licenseKey: 'MKT-VIRAL-SEP-2025-002-def222',
+    status: MKT_LICENSE_STATUS.ACTIVE,
+    activatedAt: new Date('2025-09-15T00:00:00.000Z'),
+    expiresAt: new Date('2026-09-15T00:00:00.000Z'),
+    lastLoginAt: new Date('2025-10-07T14:20:00.000Z'), // Hoạt động gần đây
+    deviceInfo: 'macOS Ventura - Safari Browser - IP: 10.0.1.65',
+    notes: 'License tháng trước - user hoạt động tích cực',
+    mktOrderId: MKT_ORDER_DATA_SEEDS_IDS.ID_2,
+    mktVariantId: MKT_VARIANT_DATA_SEEDS_IDS.MKT_VIRAL_BASIC_1_YEAR,
+    mktCustomerId: MKT_CUSTOMER_DATA_SEEDS_IDS.ID_2,
+    position: 37,
+    createdBySource: 'API',
+    createdByWorkspaceMemberId: null,
+    createdByName: 'September Active User',
+  },
+  {
+    id: MKT_LICENSE_DATA_SEEDS_IDS.ID_38,
+    name: 'License MKT Insta Basic - Tạo cuối tháng 9',
+    licenseKey: 'MKT-INSTA-SEP-2025-003-ghi333',
+    status: MKT_LICENSE_STATUS.ACTIVE,
+    activatedAt: new Date('2025-09-28T00:00:00.000Z'),
+    expiresAt: new Date('2026-09-28T00:00:00.000Z'),
+    lastLoginAt: new Date('2025-09-30T16:45:00.000Z'),
+    deviceInfo: 'Ubuntu 22.04 - Firefox Browser - IP: 172.16.0.35',
+    notes: 'License tạo cuối tháng 9',
+    mktOrderId: MKT_ORDER_DATA_SEEDS_IDS.ID_4,
+    mktVariantId: MKT_VARIANT_DATA_SEEDS_IDS.MKT_INSTA_BASIC_2_YEAR,
+    mktCustomerId: MKT_CUSTOMER_DATA_SEEDS_IDS.ID_4,
+    position: 38,
+    createdBySource: 'API',
+    createdByWorkspaceMemberId: null,
+    createdByName: 'Late September User',
+  },
+  {
+    id: MKT_LICENSE_DATA_SEEDS_IDS.ID_39,
+    name: 'License MKT Page Premium - Tháng 9 - hoạt động thường xuyên',
+    licenseKey: 'MKT-PAGE-SEP-2025-004-jkl444',
+    status: MKT_LICENSE_STATUS.ACTIVE,
+    activatedAt: new Date('2025-09-20T00:00:00.000Z'),
+    expiresAt: new Date('2027-09-20T00:00:00.000Z'),
+    lastLoginAt: new Date('2025-10-06T09:15:00.000Z'), // Hoạt động gần đây
+    deviceInfo: 'Windows 10 - Edge Browser - IP: 192.168.2.85',
+    notes: 'License tháng 9 - user thường xuyên',
+    mktOrderId: MKT_ORDER_DATA_SEEDS_IDS.ID_10,
+    mktVariantId: MKT_VARIANT_DATA_SEEDS_IDS.MKT_PAGE_BASIC_2_YEAR,
+    mktCustomerId: MKT_CUSTOMER_DATA_SEEDS_IDS.ID_10,
+    position: 39,
+    createdBySource: 'API',
+    createdByWorkspaceMemberId: null,
+    createdByName: 'September Regular User',
+  },
+  {
+    id: MKT_LICENSE_DATA_SEEDS_IDS.ID_40,
+    name: 'License MKT Maps Basic - Tháng 9 - ít hoạt động',
+    licenseKey: 'MKT-MAPS-SEP-2025-005-mno555',
+    status: MKT_LICENSE_STATUS.ACTIVE,
+    activatedAt: new Date('2025-09-12T00:00:00.000Z'),
+    expiresAt: new Date('2026-09-12T00:00:00.000Z'),
+    lastLoginAt: new Date('2025-09-20T11:30:00.000Z'),
+    deviceInfo: 'iOS 16 - Safari Mobile - IP: 172.20.0.55',
+    notes: 'License tháng 9 - ít hoạt động',
+    mktOrderId: MKT_ORDER_DATA_SEEDS_IDS.ID_11,
+    mktVariantId: MKT_VARIANT_DATA_SEEDS_IDS.MKT_MAPS_BASIC_1_YEAR,
+    mktCustomerId: MKT_CUSTOMER_DATA_SEEDS_IDS.ID_11,
+    position: 40,
+    createdBySource: 'API',
+    createdByWorkspaceMemberId: null,
+    createdByName: 'September Light User',
+  },
+
+  // 2. LICENSES HOẠT ĐỘNG HÔM QUA (8/10/2025)
+  {
+    id: MKT_LICENSE_DATA_SEEDS_IDS.ID_41,
+    name: 'License MKT Care Pro - Đăng nhập hôm qua',
+    licenseKey: 'MKT-CARE-YTD-2025-001-pqr666',
+    status: MKT_LICENSE_STATUS.ACTIVE,
+    activatedAt: new Date('2024-08-15T00:00:00.000Z'),
+    expiresAt: new Date('2025-12-31T23:59:59.000Z'),
+    lastLoginAt: new Date('2025-10-08T08:45:00.000Z'), // Hôm qua
+    deviceInfo: 'Windows 11 - Chrome Browser - IP: 192.168.1.115',
+    notes: 'License đăng nhập hôm qua',
+    mktOrderId: MKT_ORDER_DATA_SEEDS_IDS.ID_1,
+    mktVariantId: MKT_VARIANT_DATA_SEEDS_IDS.MKT_CARE_BASIC_1_YEAR,
+    mktCustomerId: MKT_CUSTOMER_DATA_SEEDS_IDS.ID_1,
+    position: 41,
+    createdBySource: 'API',
+    createdByWorkspaceMemberId: null,
+    createdByName: 'Yesterday User 1',
+  },
+  {
+    id: MKT_LICENSE_DATA_SEEDS_IDS.ID_42,
+    name: 'License MKT Viral Basic - Hoạt động hôm qua',
+    licenseKey: 'MKT-VIRAL-YTD-2025-002-stu777',
+    status: MKT_LICENSE_STATUS.ACTIVE,
+    activatedAt: new Date('2024-12-01T00:00:00.000Z'),
+    expiresAt: new Date('2025-12-01T00:00:00.000Z'),
+    lastLoginAt: new Date('2025-10-08T15:30:00.000Z'), // Hôm qua
+    deviceInfo: 'macOS Sonoma - Safari Browser - IP: 10.0.2.70',
+    notes: 'License hoạt động hôm qua',
+    mktOrderId: MKT_ORDER_DATA_SEEDS_IDS.ID_2,
+    mktVariantId: MKT_VARIANT_DATA_SEEDS_IDS.MKT_VIRAL_BASIC_1_YEAR,
+    mktCustomerId: MKT_CUSTOMER_DATA_SEEDS_IDS.ID_2,
+    position: 42,
+    createdBySource: 'API',
+    createdByWorkspaceMemberId: null,
+    createdByName: 'Yesterday User 2',
+  },
+  {
+    id: MKT_LICENSE_DATA_SEEDS_IDS.ID_43,
+    name: 'License MKT Insta Pro - Login hôm qua',
+    licenseKey: 'MKT-INSTA-YTD-2025-003-vwx888',
+    status: MKT_LICENSE_STATUS.ACTIVE,
+    activatedAt: new Date('2025-01-15T00:00:00.000Z'),
+    expiresAt: new Date('2026-01-15T00:00:00.000Z'),
+    lastLoginAt: new Date('2025-10-08T19:15:00.000Z'), // Hôm qua
+    deviceInfo: 'Android 14 - Chrome Mobile - IP: 192.168.3.40',
+    notes: 'License đăng nhập hôm qua tối',
+    mktOrderId: MKT_ORDER_DATA_SEEDS_IDS.ID_4,
+    mktVariantId: MKT_VARIANT_DATA_SEEDS_IDS.MKT_INSTA_BASIC_2_YEAR,
+    mktCustomerId: MKT_CUSTOMER_DATA_SEEDS_IDS.ID_4,
+    position: 43,
+    createdBySource: 'API',
+    createdByWorkspaceMemberId: null,
+    createdByName: 'Yesterday User 3',
+  },
+
+  // 3. LICENSES DÙNG THỬ THÁNG TRƯỚC
+  {
+    id: MKT_LICENSE_DATA_SEEDS_IDS.ID_44,
+    name: 'License MKT Care Trial - Dùng thử tháng 9 (đã hết hạn)',
+    licenseKey: 'MKT-CARE-TRIAL-SEP-2025-001-yzab999',
+    status: MKT_LICENSE_STATUS.TRIAL,
+    activatedAt: new Date('2025-09-01T00:00:00.000Z'),
+    expiresAt: new Date('2025-09-08T23:59:59.000Z'), // Trial 7 ngày đã hết hạn
+    lastLoginAt: new Date('2025-09-07T14:20:00.000Z'),
+    deviceInfo: 'Windows 10 - Chrome Browser - IP: 192.168.4.60',
+    notes: 'Trial tháng 9 - đã hết hạn, chưa chuyển đổi',
+    mktOrderId: MKT_ORDER_DATA_SEEDS_IDS.ID_1,
+    mktVariantId: MKT_VARIANT_DATA_SEEDS_IDS.MKT_CARE_BASIC_1_YEAR,
+    mktCustomerId: MKT_CUSTOMER_DATA_SEEDS_IDS.ID_1,
+    position: 44,
+    createdBySource: 'API',
+    createdByWorkspaceMemberId: null,
+    createdByName: 'Trial User Sep 1',
+  },
+  {
+    id: MKT_LICENSE_DATA_SEEDS_IDS.ID_45,
+    name: 'License MKT Maps Trial - Dùng thử tháng 9 (còn hoạt động)',
+    licenseKey: 'MKT-MAPS-TRIAL-SEP-2025-002-cdef000',
+    status: MKT_LICENSE_STATUS.TRIAL,
+    activatedAt: new Date('2025-09-20T00:00:00.000Z'),
+    expiresAt: new Date('2025-10-20T23:59:59.000Z'), // Trial 30 ngày vẫn còn
+    lastLoginAt: new Date('2025-10-05T10:30:00.000Z'),
+    deviceInfo: 'macOS Ventura - Firefox Browser - IP: 10.0.3.90',
+    notes: 'Trial tháng 9 - vẫn còn hoạt động 30 ngày',
+    mktOrderId: MKT_ORDER_DATA_SEEDS_IDS.ID_11,
+    mktVariantId: MKT_VARIANT_DATA_SEEDS_IDS.MKT_MAPS_BASIC_1_YEAR,
+    mktCustomerId: MKT_CUSTOMER_DATA_SEEDS_IDS.ID_11,
+    position: 45,
+    createdBySource: 'API',
+    createdByWorkspaceMemberId: null,
+    createdByName: 'Trial User Sep 2',
+  },
+
+  // 4. LICENSES HẾT HẠN THÁNG TRƯỚC
+  {
+    id: MKT_LICENSE_DATA_SEEDS_IDS.ID_46,
+    name: 'License MKT Tube Basic - Hết hạn 15/9/2025',
+    licenseKey: 'MKT-TUBE-EXP-SEP-2025-001-ghij111',
+    status: MKT_LICENSE_STATUS.EXPIRED,
+    activatedAt: new Date('2024-09-15T00:00:00.000Z'),
+    expiresAt: new Date('2025-09-15T23:59:59.000Z'), // Hết hạn tháng 9
+    lastLoginAt: new Date('2025-09-14T16:30:00.000Z'),
+    deviceInfo: 'Windows 11 - Edge Browser - IP: 192.168.5.25',
+    notes: 'License hết hạn giữa tháng 9/2025',
+    mktOrderId: MKT_ORDER_DATA_SEEDS_IDS.ID_5,
+    mktVariantId: MKT_VARIANT_DATA_SEEDS_IDS.MKT_TUBE_BASIC_1_YEAR,
+    mktCustomerId: MKT_CUSTOMER_DATA_SEEDS_IDS.ID_5,
+    position: 46,
+    createdBySource: 'API',
+    createdByWorkspaceMemberId: null,
+    createdByName: 'Expired Sep User 1',
+  },
+  {
+    id: MKT_LICENSE_DATA_SEEDS_IDS.ID_47,
+    name: 'License MKT Post Pro - Hết hạn 20/9/2025',
+    licenseKey: 'MKT-POST-EXP-SEP-2025-002-klmn222',
+    status: MKT_LICENSE_STATUS.EXPIRED,
+    activatedAt: new Date('2024-09-20T00:00:00.000Z'),
+    expiresAt: new Date('2025-09-20T23:59:59.000Z'), // Hết hạn tháng 9
+    lastLoginAt: new Date('2025-09-19T12:45:00.000Z'),
+    deviceInfo: 'macOS Monterey - Safari Browser - IP: 10.0.4.80',
+    notes: 'License hết hạn 20/9/2025',
+    mktOrderId: MKT_ORDER_DATA_SEEDS_IDS.ID_6,
+    mktVariantId: MKT_VARIANT_DATA_SEEDS_IDS.MKT_POST_BASIC_1_YEAR,
+    mktCustomerId: MKT_CUSTOMER_DATA_SEEDS_IDS.ID_6,
+    position: 47,
+    createdBySource: 'API',
+    createdByWorkspaceMemberId: null,
+    createdByName: 'Expired Sep User 2',
+  },
+  {
+    id: MKT_LICENSE_DATA_SEEDS_IDS.ID_48,
+    name: 'License MKT Zalo Basic - Hết hạn cuối tháng 9',
+    licenseKey: 'MKT-ZALO-EXP-SEP-2025-003-opqr333',
+    status: MKT_LICENSE_STATUS.EXPIRED,
+    activatedAt: new Date('2024-09-25T00:00:00.000Z'),
+    expiresAt: new Date('2025-09-25T23:59:59.000Z'), // Hết hạn cuối tháng 9
+    lastLoginAt: new Date('2025-09-24T09:20:00.000Z'),
+    deviceInfo: 'Ubuntu 22.04 - Chrome Browser - IP: 172.16.2.45',
+    notes: 'License hết hạn cuối tháng 9/2025',
+    mktOrderId: MKT_ORDER_DATA_SEEDS_IDS.ID_7,
+    mktVariantId: MKT_VARIANT_DATA_SEEDS_IDS.MKT_ZALO_BASIC_2_YEAR,
+    mktCustomerId: MKT_CUSTOMER_DATA_SEEDS_IDS.ID_7,
+    position: 48,
+    createdBySource: 'API',
+    createdByWorkspaceMemberId: null,
+    createdByName: 'Expired Sep User 3',
+  },
+
+  // 5. LICENSES HOÀN TIỀN THÁNG TRƯỚC
+  {
+    id: MKT_LICENSE_DATA_SEEDS_IDS.ID_49,
+    name: 'License MKT Group Premium - Hoàn tiền $399 tháng 9',
+    licenseKey: 'MKT-GROUP-REF-SEP-2025-001-stuv444',
+    status: MKT_LICENSE_STATUS.REFUND,
+    activatedAt: new Date('2025-08-15T00:00:00.000Z'),
+    expiresAt: new Date('2026-08-15T00:00:00.000Z'),
+    lastLoginAt: new Date('2025-09-10T11:15:00.000Z'),
+    deviceInfo: 'Windows 11 - Firefox Browser - IP: 192.168.6.50',
+    notes: 'License hoàn tiền $399 ngày 12/9/2025 - không hài lòng dịch vụ',
+    mktOrderId: MKT_ORDER_DATA_SEEDS_IDS.ID_8,
+    mktVariantId: MKT_VARIANT_DATA_SEEDS_IDS.MKT_GROUP_BASIC_1_YEAR,
+    mktCustomerId: MKT_CUSTOMER_DATA_SEEDS_IDS.ID_8,
+    position: 49,
+    createdBySource: 'API',
+    createdByWorkspaceMemberId: null,
+    createdByName: 'Refund Sep User 1',
+  },
+  {
+    id: MKT_LICENSE_DATA_SEEDS_IDS.ID_50,
+    name: 'License MKT UID Basic - Hoàn tiền $199 tháng 9',
+    licenseKey: 'MKT-UID-REF-SEP-2025-002-wxyz555',
+    status: MKT_LICENSE_STATUS.REFUND,
+    activatedAt: new Date('2025-09-05T00:00:00.000Z'),
+    expiresAt: new Date('2026-09-05T00:00:00.000Z'),
+    lastLoginAt: new Date('2025-09-18T15:40:00.000Z'),
+    deviceInfo: 'macOS Sonoma - Chrome Browser - IP: 10.0.5.95',
+    notes: 'License hoàn tiền $199 ngày 20/9/2025 - lỗi kỹ thuật',
+    mktOrderId: MKT_ORDER_DATA_SEEDS_IDS.ID_3,
+    mktVariantId: MKT_VARIANT_DATA_SEEDS_IDS.MKT_UID_BASIC_1_YEAR,
+    mktCustomerId: MKT_CUSTOMER_DATA_SEEDS_IDS.ID_3,
+    position: 50,
+    createdBySource: 'API',
+    createdByWorkspaceMemberId: null,
+    createdByName: 'Refund Sep User 2',
   }
 ];

--- a/packages/twenty-server/src/mkt-core/dev-seeder/constants/mkt-report-data-seeds.constants.ts
+++ b/packages/twenty-server/src/mkt-core/dev-seeder/constants/mkt-report-data-seeds.constants.ts
@@ -1,0 +1,48 @@
+type MktReportDataSeed = {
+  id: string;
+  name: string;
+  reportType: string;
+  metadata: string; // JSON string
+  notes: string;
+
+  position: number;
+  createdBySource: string;
+  createdByWorkspaceMemberId: string | null;
+  createdByName: string;
+};
+
+export const MKT_REPORT_DATA_SEED_COLUMNS: (keyof MktReportDataSeed)[] = [
+  'id',
+  'name',
+  'reportType',
+  'metadata',
+  'notes',
+  'position',
+  'createdBySource',
+  'createdByWorkspaceMemberId',
+  'createdByName',
+];
+
+// prettier-ignore
+export const MKT_REPORT_DATA_SEEDS_IDS = {
+  ID_1: 'b8acdd19-4852-415a-a783-83bd1231381c',
+};
+
+// prettier-ignore
+export const MKT_REPORT_DATA_SEEDS: MktReportDataSeed[] = [
+  {
+    id: MKT_REPORT_DATA_SEEDS_IDS.ID_1,
+    name: 'Monthly Sales Report',
+    reportType: 'sales',
+    metadata: JSON.stringify({
+      period: 'monthly',
+      metrics: ['totalSales', 'newCustomers', 'returningCustomers'],
+      filters: { region: 'all', productCategory: 'all' },
+    }),
+    notes: 'A comprehensive report detailing monthly sales performance.',
+    position: 1,
+    createdBySource: 'MANUAL',
+    createdByWorkspaceMemberId: null,
+    createdByName: 'Admin User',
+  },
+];

--- a/packages/twenty-server/src/mkt-core/enums/mkt-database-command.module.ts
+++ b/packages/twenty-server/src/mkt-core/enums/mkt-database-command.module.ts
@@ -34,9 +34,13 @@ import { SeedComboVariantModuleCommand } from 'src/mkt-core/dev-seeder/product-s
 import { SeedProductModuleCommand } from 'src/mkt-core/dev-seeder/product-seeder/mkt-product-data-seed-dev-workspace.command';
 import { SeedVariantModuleCommand } from 'src/mkt-core/dev-seeder/product-seeder/mkt-variant-data-seed-dev-workspace.command';
 import { SeedVariantValueModuleCommand } from 'src/mkt-core/dev-seeder/product-seeder/mkt-variant-value-data-seed-dev-workspace.command';
+import { MktLicenseDashboardStatsCommand } from 'src/mkt-core/license/commands/mkt-license-dashboard-stats.command';
 import { EnsureOrderUpdatedAtTriggerCommand } from 'src/mkt-core/order/commands/mkt-order-optimistic-locking.command';
+import { SeedMktReportModuleCommand } from 'src/mkt-core/report/seeder/mkt-report-data-seed-dev-workspace.command';
 
 export const MKT_DATABASE_COMMAND_MODULES = [
+  // report commands
+  SeedMktReportModuleCommand,
   // i18n commands
   SeedI18nModuleCommand,
   // customer commands
@@ -61,6 +65,7 @@ export const MKT_DATABASE_COMMAND_MODULES = [
   // license commands
   SeedLicenseModuleCommand,
   SeedLicenseHistoryModuleCommand,
+  MktLicenseDashboardStatsCommand,
   // invoice commands
   SeedSInvoiceAuthModuleCommand,
   SeedSInvoiceModuleCommand,

--- a/packages/twenty-server/src/mkt-core/enums/mkt-dev-seeder-data.config.ts
+++ b/packages/twenty-server/src/mkt-core/enums/mkt-dev-seeder-data.config.ts
@@ -84,6 +84,10 @@ import {
   MKT_PERMISSION_AUDIT_DATA_SEEDS,
 } from 'src/mkt-core/dev-seeder/constants/mkt-permission-audit-data-seeds.constants';
 import {
+  MKT_REPORT_DATA_SEED_COLUMNS,
+  MKT_REPORT_DATA_SEEDS,
+} from 'src/mkt-core/dev-seeder/constants/mkt-report-data-seeds.constants';
+import {
   MKT_RESELLER_DATA_SEED_COLUMNS,
   MKT_RESELLER_DATA_SEEDS,
 } from 'src/mkt-core/dev-seeder/constants/mkt-reseller-data-seeds.constants';
@@ -96,6 +100,10 @@ import {
   MKT_RESELLER_TIER_HISTORY_DATA_SEEDS,
 } from 'src/mkt-core/dev-seeder/constants/mkt-reseller-tier-history-data-seeds.constants';
 import {
+  MKT_SENDMAIL_TEMPLATE_DATA_SEED_COLUMNS,
+  MKT_SENDMAIL_TEMPLATE_DATA_SEEDS,
+} from 'src/mkt-core/dev-seeder/constants/mkt-sendmail-template-seeds.constant.ts';
+import {
   MKT_STAFF_STATUS_HISTORY_DATA_SEED_COLUMNS,
   MKT_STAFF_STATUS_HISTORY_DATA_SEEDS,
 } from 'src/mkt-core/dev-seeder/constants/mkt-staff-status-history-data-seeds.constants';
@@ -107,10 +115,6 @@ import {
   MKT_TEMPLATE_DATA_SEED_COLUMNS,
   MKT_TEMPLATE_DATA_SEEDS,
 } from 'src/mkt-core/dev-seeder/constants/mkt-template-data-seeds.constants';
-import {
-  MKT_SENDMAIL_TEMPLATE_DATA_SEED_COLUMNS,
-  MKT_SENDMAIL_TEMPLATE_DATA_SEEDS,
-} from 'src/mkt-core/dev-seeder/constants/mkt-sendmail-template-seeds.constant.ts';
 import {
   MKT_TEMPORARY_PERMISSION_DATA_SEED_COLUMNS,
   MKT_TEMPORARY_PERMISSION_DATA_SEEDS,
@@ -342,6 +346,12 @@ export const MKT_RECORD_SEEDS_CONFIGS = [
     tableName: 'mktKpiTemplate',
     pgColumns: MKT_KPI_TEMPLATE_DATA_SEED_COLUMNS,
     recordSeeds: MKT_KPI_TEMPLATE_DATA_SEEDS,
+  },
+  //reports
+  {
+    tableName: 'mktReport',
+    pgColumns: MKT_REPORT_DATA_SEED_COLUMNS,
+    recordSeeds: MKT_REPORT_DATA_SEEDS,
   },
   // Customer configs
   {

--- a/packages/twenty-server/src/mkt-core/enums/mkt-objects-prefill-data.ts
+++ b/packages/twenty-server/src/mkt-core/enums/mkt-objects-prefill-data.ts
@@ -35,8 +35,11 @@ import { prefillMktCombos } from 'src/mkt-core/dev-seeder/product-seeder/prefill
 import { prefillMktProducts } from 'src/mkt-core/dev-seeder/product-seeder/prefill-mkt-products';
 import { prefillMktVariantValues } from 'src/mkt-core/dev-seeder/product-seeder/prefill-mkt-variant-values';
 import { prefillMktVariants } from 'src/mkt-core/dev-seeder/product-seeder/prefill-mkt-variants';
+import { prefillMktReports } from 'src/mkt-core/report/seeder/prefill-mkt-reports';
 
 export const MKT_PREFILLS = [
+  // report prefills
+  prefillMktReports,
   // i18n prefills
   prefillMktI18n,
   // customer prefills

--- a/packages/twenty-server/src/mkt-core/enums/mkt-prefill-views.ts
+++ b/packages/twenty-server/src/mkt-core/enums/mkt-prefill-views.ts
@@ -34,8 +34,11 @@ import { mktComboVariantsAllView } from 'src/mkt-core/dev-seeder/product-seeder/
 import { mktProductsAllView } from 'src/mkt-core/dev-seeder/product-seeder/mkt-product-all.view';
 import { mktVariantsAllView } from 'src/mkt-core/dev-seeder/product-seeder/mkt-variant-all.view';
 import { mktVariantValuesAllView } from 'src/mkt-core/dev-seeder/product-seeder/mkt-variant-value-all.view';
+import { mktReportsAllView } from 'src/mkt-core/report/seeder/mkt-report-all.view';
 
 export const MKT_ALL_VIEWS = [
+  // report views
+  mktReportsAllView,
   // i18n views
   mktI18nAllView,
   // customer views

--- a/packages/twenty-server/src/mkt-core/enums/mkt.workspace.entities.ts
+++ b/packages/twenty-server/src/mkt-core/enums/mkt.workspace.entities.ts
@@ -41,6 +41,7 @@ import { MktProductWorkspaceEntity } from 'src/mkt-core/product/objects/mkt-prod
 import { MktValueWorkspaceEntity } from 'src/mkt-core/product/objects/mkt-value.workspace-entity';
 import { MktVariantValueWorkspaceEntity } from 'src/mkt-core/product/objects/mkt-variant-value.workspace-entity';
 import { MktVariantWorkspaceEntity } from 'src/mkt-core/product/objects/mkt-variant.workspace-entity';
+import { MktReportWorkspaceEntity } from 'src/mkt-core/report/objects/mkt-report.workspace-entity';
 
 export const MKT_WORKSPACE_ENTITIES = [
   // I18n
@@ -81,6 +82,8 @@ export const MKT_WORKSPACE_ENTITIES = [
   // Payment
   MktPaymentMethodWorkspaceEntity,
   MktPaymentWorkspaceEntity,
+  // Report
+  MktReportWorkspaceEntity,
   // Seller Tier
   MktResellerTierWorkspaceEntity,
   MktResellerWorkspaceEntity,

--- a/packages/twenty-server/src/mkt-core/license/commands/mkt-license-dashboard-stats.command.ts
+++ b/packages/twenty-server/src/mkt-core/license/commands/mkt-license-dashboard-stats.command.ts
@@ -1,0 +1,1089 @@
+import { Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+
+import { Command, CommandRunner, Option } from 'nest-commander';
+import { WorkspaceActivationStatus } from 'twenty-shared/workspace';
+import { Repository } from 'typeorm';
+
+import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';
+import { ObjectMetadataService } from 'src/engine/metadata-modules/object-metadata/object-metadata.service';
+import { TwentyORMGlobalManager } from 'src/engine/twenty-orm/twenty-orm-global.manager';
+import { WorkspaceCacheStorageService } from 'src/engine/workspace-cache-storage/workspace-cache-storage.service';
+import { getWorkspaceSchemaName } from 'src/engine/workspace-datasource/utils/get-workspace-schema-name.util';
+import { WorkspaceDataSourceService } from 'src/engine/workspace-datasource/workspace-datasource.service';
+import { MktReportWorkspaceEntity } from 'src/mkt-core/report/objects/mkt-report.workspace-entity';
+import { DateRangeUtils } from 'src/mkt-core/utils';
+import {
+  DashboardDataTransformer,
+  LicenseStats,
+} from 'src/mkt-core/utils/dashboard-data-transformer.utils';
+
+interface DashboardOptions {
+  workspaceId?: string;
+  format?: 'json' | 'table';
+  detailed?: boolean;
+}
+
+interface _LicenseReportMetadata {
+  generatedAt: string;
+  workspaceId: string;
+  statistics: LicenseStats;
+}
+
+@Command({
+  name: 'workspace:license:dashboard:stats',
+  description:
+    'Generate comprehensive license dashboard statistics and analytics',
+})
+export class MktLicenseDashboardStatsCommand extends CommandRunner {
+  private readonly logger = new Logger(MktLicenseDashboardStatsCommand.name);
+
+  constructor(
+    @InjectRepository(Workspace, 'core')
+    private readonly workspaceRepository: Repository<Workspace>,
+    private readonly objectMetadataService: ObjectMetadataService,
+    private readonly workspaceDataSourceService: WorkspaceDataSourceService,
+    private readonly workspaceCacheStorageService: WorkspaceCacheStorageService,
+    private readonly twentyORMGlobalManager: TwentyORMGlobalManager,
+  ) {
+    super();
+  }
+
+  @Option({
+    flags: '-w, --workspace-id [workspace_id]',
+    description: 'Workspace ID to generate statistics for',
+  })
+  parseWorkspaceId(value: string): string {
+    return value;
+  }
+
+  @Option({
+    flags: '-f, --format [format]',
+    description: 'Output format: json or table (default: table)',
+    defaultValue: 'table',
+  })
+  parseFormat(value: string): 'json' | 'table' {
+    return value === 'json' ? 'json' : 'table';
+  }
+
+  @Option({
+    flags: '-d, --detailed',
+    description:
+      'Show detailed information including lists of expiring licenses',
+  })
+  parseDetailed(): boolean {
+    return true;
+  }
+
+  async run(passedParam: string[], options: DashboardOptions): Promise<void> {
+    let workspaces: Workspace[] = [];
+
+    try {
+      if (options.workspaceId) {
+        const workspace = await this.workspaceRepository.findOne({
+          where: { id: options.workspaceId },
+        });
+
+        if (workspace) {
+          workspaces = [workspace];
+        } else {
+          this.logger.error(`Workspace ${options.workspaceId} not found`);
+
+          return;
+        }
+      } else {
+        // Generate stats for all active workspaces
+        workspaces = await this.workspaceRepository.find({
+          where: {
+            activationStatus: WorkspaceActivationStatus.ACTIVE,
+          },
+        });
+      }
+
+      for (const workspace of workspaces) {
+        try {
+          this.logger.log(
+            `🚀 Generating license dashboard statistics for workspace: ${workspace.displayName || workspace.id}`,
+          );
+
+          const stats = await this.getLicenseStatsForWorkspace(workspace.id);
+
+          if (!stats) {
+            this.logger.warn(
+              `⚠️ Could not generate statistics for workspace ${workspace.id} - license table may not exist`,
+            );
+            continue;
+          }
+
+          // Save results to mktReport
+          await this.saveLicenseStatsToReport(workspace.id, stats);
+
+          // Output the results
+          if (options.format === 'json') {
+            await this.outputJSON(workspace, stats);
+          } else {
+            await this.outputTable(workspace, stats, options);
+          }
+
+          this.logger.log(
+            `✅ License dashboard statistics generated and saved to report for workspace: ${workspace.id}`,
+          );
+        } catch (error) {
+          this.logger.error(
+            `❌ Failed to generate license statistics for workspace ${workspace.id}:`,
+            error,
+          );
+        }
+      }
+    } catch (error) {
+      this.logger.error(
+        '❌ Fatal error in license dashboard stats command:',
+        error,
+      );
+    } finally {
+      // Add a small delay to allow any pending async operations to complete
+      this.logger.debug('🔄 Waiting for async operations to complete...');
+      await new Promise((resolve) => setTimeout(resolve, 200));
+      this.logger.debug('✅ License dashboard stats command completed');
+
+      // Force cleanup of any remaining connections
+      try {
+        // Give a bit more time for cleanup
+        await new Promise((resolve) => setTimeout(resolve, 100));
+      } catch (cleanupError) {
+        this.logger.warn('⚠️ Minor cleanup error:', cleanupError?.message);
+      }
+    }
+  }
+
+  private async validateConnection(dataSource: {
+    isInitialized: boolean;
+    query: (sql: string) => Promise<unknown>;
+  }): Promise<boolean> {
+    try {
+      if (!dataSource || !dataSource.isInitialized) {
+        this.logger.warn('⚠️ Data source is not initialized');
+
+        return false;
+      }
+
+      // Try a simple query to test connection
+      await dataSource.query('SELECT 1');
+
+      return true;
+    } catch (error) {
+      this.logger.warn(`⚠️ Connection validation failed: ${error?.message}`);
+
+      return false;
+    }
+  }
+
+  private async getLicenseStatsForWorkspace(
+    workspaceId: string,
+  ): Promise<LicenseStats | null> {
+    let retryCount = 0;
+    const maxRetries = 2;
+
+    while (retryCount <= maxRetries) {
+      try {
+        this.logger.debug(
+          `🔌 Attempt ${retryCount + 1}: Connecting to main data source for workspace ${workspaceId}`,
+        );
+        const mainDataSource =
+          await this.workspaceDataSourceService.connectToMainDataSource();
+
+        if (!mainDataSource) {
+          throw new Error('Could not connect to main data source');
+        }
+
+        this.logger.debug(
+          `✅ Connected to data source, isInitialized: ${mainDataSource.isInitialized}`,
+        );
+
+        // Add connection validation
+        if (!mainDataSource.isInitialized) {
+          throw new Error('Data source is not initialized');
+        }
+
+        this.logger.debug(
+          `📋 Fetching object metadata for workspace ${workspaceId}`,
+        );
+        const objectMetadataItems =
+          await this.objectMetadataService.findManyWithinWorkspace(workspaceId);
+
+        // Find license object metadata
+        const licenseObjectMetadata = objectMetadataItems.find(
+          (item) => item.nameSingular === 'mktLicense',
+        );
+
+        if (!licenseObjectMetadata) {
+          this.logger.log(
+            `License object not found in workspace ${workspaceId}, skipping...`,
+          );
+
+          return null;
+        }
+
+        const schemaName = getWorkspaceSchemaName(workspaceId);
+
+        this.logger.debug(`📊 Using schema: ${schemaName}`);
+
+        // Get date ranges for comparison
+        const currentMonth = DateRangeUtils.getCurrentMonth();
+        const lastMonth = DateRangeUtils.getLastMonth();
+
+        // Debug date ranges
+        this.logger.debug(`📅 Date ranges for expired license calculations:`);
+        this.logger.debug(
+          `   Current month: ${DateRangeUtils.toISOString(currentMonth.start)} to ${DateRangeUtils.toISOString(new Date(currentMonth.start.getFullYear(), currentMonth.start.getMonth() + 1, 1))}`,
+        );
+        this.logger.debug(
+          `   Last month: ${DateRangeUtils.toISOString(lastMonth.start)} to ${DateRangeUtils.toISOString(currentMonth.start)}`,
+        );
+
+        // Get total licenses count (all time)
+        this.logger.debug(`🔍 Query 1: Getting total licenses count`);
+        if (!(await this.validateConnection(mainDataSource))) {
+          throw new Error('Connection lost before Query 1');
+        }
+        const totalLicensesAllTime = await mainDataSource.query(
+          `SELECT COUNT(*) as count FROM "${schemaName}"."mktLicense"`,
+        );
+
+        this.logger.debug(
+          `✅ Query 1 completed: ${totalLicensesAllTime?.[0]?.count || '0'} total licenses`,
+        );
+
+        // Get current month license count
+        this.logger.debug(`🔍 Query 2: Getting current month license count`);
+        const currentMonthLicensesQuery = `SELECT COUNT(*) as count FROM "${schemaName}"."mktLicense" WHERE "createdAt" >= $1`;
+        const currentMonthLicenses = await mainDataSource.query(
+          currentMonthLicensesQuery,
+          [DateRangeUtils.toISOString(currentMonth.start)],
+        );
+
+        this.logger.log(
+          `✅ Query 2 completed: ${currentMonthLicensesQuery} current month licenses`,
+          DateRangeUtils.toISOString(currentMonth.start),
+        );
+
+        // Get last month license count
+        this.logger.debug(`🔍 Query 3: Getting last month license count`);
+        const lastMonthLicenses = await mainDataSource.query(
+          `SELECT COUNT(*) as count FROM "${schemaName}"."mktLicense" WHERE "createdAt" >= $1 AND "createdAt" <= $2`,
+          [
+            DateRangeUtils.toISOString(lastMonth.start),
+            DateRangeUtils.toISOString(lastMonth.end),
+          ],
+        );
+
+        this.logger.debug(
+          `✅ Query 3 completed: ${lastMonthLicenses?.[0]?.count || '0'} last month licenses`,
+        );
+
+        // Get total active licenses
+        this.logger.debug(`🔍 Query 4: Getting active licenses count`);
+        const activeLicenses = await mainDataSource.query(
+          `SELECT COUNT(*) as count FROM "${schemaName}"."mktLicense" WHERE "status" = $1`,
+          ['ACTIVE'],
+        );
+
+        this.logger.debug(
+          `✅ Query 4 completed: ${activeLicenses?.[0]?.count || '0'} active licenses`,
+        );
+
+        // Get today and yesterday date ranges for active license comparison
+        const today = DateRangeUtils.getToday();
+        const yesterday = DateRangeUtils.getYesterday();
+
+        // Get active licenses with login today
+        this.logger.debug(`🔍 Query 5: Getting today's active licenses`);
+        const todayActiveLicenses = await mainDataSource.query(
+          `SELECT COUNT(*) as count FROM "${schemaName}"."mktLicense" WHERE "status" = $1 AND "lastLoginAt" >= $2`,
+          ['ACTIVE', DateRangeUtils.toISOString(today.start)],
+        );
+
+        this.logger.debug(
+          `✅ Query 5 completed: ${todayActiveLicenses?.[0]?.count || '0'} today's active licenses`,
+        );
+
+        // Get active licenses with login yesterday
+        this.logger.debug(`🔍 Query 6: Getting yesterday's active licenses`);
+        const yesterdayActiveLicenses = await mainDataSource.query(
+          `SELECT COUNT(*) as count FROM "${schemaName}"."mktLicense" WHERE "status" = $1 AND "lastLoginAt" >= $2 AND "lastLoginAt" <= $3`,
+          [
+            'ACTIVE',
+            DateRangeUtils.toISOString(yesterday.start),
+            DateRangeUtils.toISOString(yesterday.end),
+          ],
+        );
+
+        this.logger.debug(
+          `✅ Query 6 completed: ${yesterdayActiveLicenses?.[0]?.count || '0'} yesterday's active licenses`,
+        );
+
+        this.logger.debug(`🔍 Query 7: Getting trial licenses count`);
+        const trialLicenses = await mainDataSource.query(
+          `SELECT COUNT(*) as count FROM "${schemaName}"."mktLicense" WHERE "status" = $1`,
+          ['TRIAL'],
+        );
+
+        this.logger.debug(
+          `✅ Query 7 completed: ${trialLicenses?.[0]?.count || '0'} trial licenses`,
+        );
+
+        // Get current month trial license count
+        this.logger.debug(
+          `🔍 Query 7a: Getting current month trial license count`,
+        );
+        const currentMonthTrialLicenses = await mainDataSource.query(
+          `SELECT COUNT(*) as count FROM "${schemaName}"."mktLicense" WHERE "status" = $1 AND "createdAt" >= $2`,
+          ['TRIAL', DateRangeUtils.toISOString(currentMonth.start)],
+        );
+
+        this.logger.debug(
+          `✅ Query 7a completed: ${currentMonthTrialLicenses?.[0]?.count || '0'} current month trial licenses`,
+        );
+
+        // Get last month trial license count
+        this.logger.debug(
+          `🔍 Query 7b: Getting last month trial license count`,
+        );
+        const lastMonthTrialLicenses = await mainDataSource.query(
+          `SELECT COUNT(*) as count FROM "${schemaName}"."mktLicense" WHERE "status" = $1 AND "createdAt" >= $2 AND "createdAt" <= $3`,
+          [
+            'TRIAL',
+            DateRangeUtils.toISOString(lastMonth.start),
+            DateRangeUtils.toISOString(lastMonth.end),
+          ],
+        );
+
+        this.logger.debug(
+          `✅ Query 7b completed: ${lastMonthTrialLicenses?.[0]?.count || '0'} last month trial licenses`,
+        );
+
+        // Get total expired licenses count
+        this.logger.debug(`🔍 Query 8: Getting total expired licenses count`);
+        const totalExpiredLicenses = await mainDataSource.query(
+          `SELECT COUNT(*) as count FROM "${schemaName}"."mktLicense" WHERE "status" = $1`,
+          ['EXPIRED'],
+        );
+
+        this.logger.debug(
+          `✅ Query 8 completed: ${totalExpiredLicenses?.[0]?.count || '0'} total expired licenses`,
+        );
+
+        // Get expired licenses stats - current month count (licenses that expired this month)
+        this.logger.debug(
+          `🔍 Query 8a: Getting current month expired licenses (by expiresAt)`,
+        );
+        const currentExpiredLicenses = await mainDataSource.query(
+          `SELECT COUNT(*) as count FROM "${schemaName}"."mktLicense" WHERE "status" = $1 AND "expiresAt" IS NOT NULL AND "expiresAt" >= $2 AND "expiresAt" < $3`,
+          [
+            'EXPIRED',
+            DateRangeUtils.toISOString(currentMonth.start),
+            DateRangeUtils.toISOString(
+              new Date(
+                currentMonth.start.getFullYear(),
+                currentMonth.start.getMonth() + 1,
+                1,
+              ),
+            ),
+          ],
+        );
+
+        this.logger.debug(
+          `✅ Query 8a completed: ${currentExpiredLicenses?.[0]?.count || '0'} current month expired licenses`,
+        );
+
+        // Get expired licenses stats - last month count (licenses that expired last month)
+        this.logger.debug(
+          `🔍 Query 8b: Getting last month expired licenses (by expiresAt)`,
+        );
+        const lastMonthExpiredLicenses = await mainDataSource.query(
+          `SELECT COUNT(*) as count FROM "${schemaName}"."mktLicense" WHERE "status" = $1 AND "expiresAt" IS NOT NULL AND "expiresAt" >= $2 AND "expiresAt" < $3`,
+          [
+            'EXPIRED',
+            DateRangeUtils.toISOString(lastMonth.start),
+            DateRangeUtils.toISOString(currentMonth.start), // End of last month = start of current month
+          ],
+        );
+
+        this.logger.debug(
+          `✅ Query 8b completed: ${lastMonthExpiredLicenses?.[0]?.count || '0'} last month expired licenses`,
+        );
+
+        // Debug query: Get detailed expired licenses info to understand the data
+        this.logger.debug(`🔍 Debug: Getting expired licenses details`);
+        const expiredLicensesDebug = await mainDataSource.query(
+          `SELECT "licenseKey", "status", "expiresAt", "createdAt", "updatedAt" FROM "${schemaName}"."mktLicense" WHERE "status" = $1 ORDER BY "expiresAt" DESC LIMIT 10`,
+          ['EXPIRED'],
+        );
+
+        this.logger.debug(
+          `✅ Debug: Found ${expiredLicensesDebug?.length || '0'} expired licenses:`,
+          expiredLicensesDebug?.map(
+            (l: {
+              licenseKey: string;
+              expiresAt: string;
+              createdAt: string;
+              updatedAt: string;
+            }) => ({
+              key: l.licenseKey,
+              expires: l.expiresAt,
+              created: l.createdAt,
+              updated: l.updatedAt,
+            }),
+          ),
+        );
+
+        this.logger.debug(`🔍 Debug Query: Getting expired licenses details`);
+        const expiredLicensesDetails = await mainDataSource.query(
+          `SELECT "id", "name", "status", "createdAt", "updatedAt" FROM "${schemaName}"."mktLicense" WHERE "status" = $1 ORDER BY "updatedAt" DESC LIMIT 10`,
+          ['EXPIRED'],
+        );
+
+        this.logger.debug(
+          `🔍 Expired Licenses Details (last 10):`,
+          JSON.stringify(expiredLicensesDetails, null, 2),
+        );
+
+        // Get refunded amount for current month (via variant → orderItem → unitPrice)
+        this.logger.debug(
+          `🔍 Query 9: Getting current month refunded amount via variant`,
+        );
+        const currentRefundedAmount = await mainDataSource.query(
+          `SELECT COALESCE(SUM(oi."unitPrice"), 0) as total_amount 
+           FROM "${schemaName}"."mktLicense" l 
+           JOIN "${schemaName}"."mktVariant" v ON l."mktVariantId" = v."id"
+           JOIN "${schemaName}"."mktOrderItem" oi ON v."id" = oi."mktVariantId"
+           WHERE l."status" = $1 AND l."updatedAt" >= $2`,
+          ['REFUND', DateRangeUtils.toISOString(currentMonth.start)],
+        );
+
+        this.logger.debug(
+          `✅ Query 9 completed: $${currentRefundedAmount?.[0]?.total_amount || '0'} current refunded amount via variant`,
+        );
+
+        // Get refunded amount for last month (via variant → orderItem → unitPrice)
+        this.logger.debug(
+          `🔍 Query 10: Getting last month refunded amount via variant`,
+        );
+        const lastMonthRefundedAmount = await mainDataSource.query(
+          `SELECT COALESCE(SUM(oi."unitPrice"), 0) as total_amount 
+           FROM "${schemaName}"."mktLicense" l 
+           JOIN "${schemaName}"."mktVariant" v ON l."mktVariantId" = v."id"
+           JOIN "${schemaName}"."mktOrderItem" oi ON v."id" = oi."mktVariantId"
+           WHERE l."status" = $1 AND l."updatedAt" >= $2 AND l."updatedAt" <= $3`,
+          [
+            'REFUND',
+            DateRangeUtils.toISOString(lastMonth.start),
+            DateRangeUtils.toISOString(lastMonth.end),
+          ],
+        );
+
+        this.logger.debug(
+          `✅ Query 10 completed: $${lastMonthRefundedAmount?.[0]?.total_amount || '0'} last month refunded amount via variant`,
+        );
+
+        // Get current month refunded licenses count
+        this.logger.debug(
+          `🔍 Query 10a: Getting current month refunded licenses count`,
+        );
+        const currentRefundedLicensesCount = await mainDataSource.query(
+          `SELECT COUNT(*) as count FROM "${schemaName}"."mktLicense" WHERE "status" = $1 AND "updatedAt" >= $2`,
+          ['REFUND', DateRangeUtils.toISOString(currentMonth.start)],
+        );
+
+        this.logger.debug(
+          `✅ Query 10a completed: ${currentRefundedLicensesCount?.[0]?.count || '0'} current refunded licenses count`,
+        );
+
+        // Get last month refunded licenses count
+        this.logger.debug(
+          `🔍 Query 10b: Getting last month refunded licenses count`,
+        );
+        const lastMonthRefundedLicensesCount = await mainDataSource.query(
+          `SELECT COUNT(*) as count FROM "${schemaName}"."mktLicense" WHERE "status" = $1 AND "updatedAt" >= $2 AND "updatedAt" <= $3`,
+          [
+            'REFUND',
+            DateRangeUtils.toISOString(lastMonth.start),
+            DateRangeUtils.toISOString(lastMonth.end),
+          ],
+        );
+
+        this.logger.debug(
+          `✅ Query 10b completed: ${lastMonthRefundedLicensesCount?.[0]?.count || '0'} last month refunded licenses count`,
+        );
+
+        // Get licenses expiring in the next 30 days
+        this.logger.debug(`🔍 Query 11: Getting expiring licenses count`);
+        const thirtyDaysFromNow = new Date();
+
+        thirtyDaysFromNow.setDate(thirtyDaysFromNow.getDate() + 30);
+
+        const expiringLicenses = await mainDataSource.query(
+          `SELECT COUNT(*) as count FROM "${schemaName}"."mktLicense" WHERE "status" = $1 AND "expiresAt" IS NOT NULL AND "expiresAt" <= $2 AND "expiresAt" > $3`,
+          ['ACTIVE', thirtyDaysFromNow.toISOString(), new Date().toISOString()],
+        );
+
+        this.logger.debug(
+          `✅ Query 11 completed: ${expiringLicenses?.[0]?.count || '0'} expiring licenses`,
+        );
+
+        // Get usage statistics
+        const todayUsage = DateRangeUtils.getToday();
+        const lastWeek = DateRangeUtils.getLastNDays(7);
+        const lastMonthUsage = DateRangeUtils.getLastNDays(30);
+
+        this.logger.debug(`🔍 Query 12: Getting usage statistics - today`);
+        const activeTodayUsage = await mainDataSource.query(
+          `SELECT COUNT(*) as count FROM "${schemaName}"."mktLicense" WHERE "status" = $1 AND "lastLoginAt" >= $2`,
+          ['ACTIVE', DateRangeUtils.toISOString(todayUsage.start)],
+        );
+
+        this.logger.debug(`🔍 Query 13: Getting usage statistics - this week`);
+        const activeThisWeek = await mainDataSource.query(
+          `SELECT COUNT(*) as count FROM "${schemaName}"."mktLicense" WHERE "status" = $1 AND "lastLoginAt" >= $2`,
+          ['ACTIVE', DateRangeUtils.toISOString(lastWeek.start)],
+        );
+
+        this.logger.debug(`🔍 Query 14: Getting usage statistics - this month`);
+        const activeThisMonth = await mainDataSource.query(
+          `SELECT COUNT(*) as count FROM "${schemaName}"."mktLicense" WHERE "status" = $1 AND "lastLoginAt" >= $2`,
+          ['ACTIVE', DateRangeUtils.toISOString(lastMonthUsage.start)],
+        );
+
+        this.logger.debug(
+          `✅ Usage statistics completed: today=${activeTodayUsage?.[0]?.count || '0'}, week=${activeThisWeek?.[0]?.count || '0'}, month=${activeThisMonth?.[0]?.count || '0'}`,
+        );
+
+        // Parse raw counts from database results
+        const totalCount = parseInt(totalLicensesAllTime?.[0]?.count || '0');
+        const currentMonthCount = parseInt(
+          currentMonthLicenses?.[0]?.count || '0',
+        );
+        const lastMonthCountVal = parseInt(
+          lastMonthLicenses?.[0]?.count || '0',
+        );
+        const activeLicensesCount = parseInt(activeLicenses?.[0]?.count || '0');
+        const todayCount = parseInt(todayActiveLicenses?.[0]?.count || '0');
+        const yesterdayCount = parseInt(
+          yesterdayActiveLicenses?.[0]?.count || '0',
+        );
+        const totalExpiredCount = parseInt(
+          totalExpiredLicenses?.[0]?.count || '0',
+        );
+        const currentExpiredCount = parseInt(
+          currentExpiredLicenses?.[0]?.count || '0',
+        );
+        const lastMonthExpiredCount = parseInt(
+          lastMonthExpiredLicenses?.[0]?.count || '0',
+        );
+        const expiringLicensesCount = parseInt(
+          expiringLicenses?.[0]?.count || '0',
+        );
+        const currentRefundedAmountValue = parseFloat(
+          currentRefundedAmount?.[0]?.total_amount || '0',
+        );
+        const lastMonthRefundedAmountValue = parseFloat(
+          lastMonthRefundedAmount?.[0]?.total_amount || '0',
+        );
+        const currentRefundedCountValue = parseInt(
+          currentRefundedLicensesCount?.[0]?.count || '0',
+        );
+        const lastMonthRefundedCountValue = parseInt(
+          lastMonthRefundedLicensesCount?.[0]?.count || '0',
+        );
+
+        // Debug refund amounts
+        this.logger.debug(
+          `📊 Debug refund amounts: Current=$${currentRefundedAmountValue}, Last=$${lastMonthRefundedAmountValue}`,
+        );
+
+        const usageActiveTodayCount = parseInt(
+          activeTodayUsage?.[0]?.count || '0',
+        );
+        const usageActiveThisWeekCount = parseInt(
+          activeThisWeek?.[0]?.count || '0',
+        );
+        const usageActiveThisMonthCount = parseInt(
+          activeThisMonth?.[0]?.count || '0',
+        );
+
+        // Parse trial licenses counts
+        const trialLicensesCount = parseInt(trialLicenses?.[0]?.count || '0');
+        const currentMonthTrialCount = parseInt(
+          currentMonthTrialLicenses?.[0]?.count || '0',
+        );
+        const lastMonthTrialCount = parseInt(
+          lastMonthTrialLicenses?.[0]?.count || '0',
+        );
+
+        // Use DashboardDataTransformer for calculations
+        const totalLicenseStats =
+          DashboardDataTransformer.transformLicenseCountStats(
+            totalCount,
+            currentMonthCount,
+            lastMonthCountVal,
+          );
+
+        const activeLicenseStats =
+          DashboardDataTransformer.transformLicenseActivityStats(
+            activeLicensesCount,
+            todayCount,
+            yesterdayCount,
+          );
+
+        // Debug expired licenses calculation
+        this.logger.debug(
+          `🔍 Expired Licenses Debug: Total=${totalExpiredCount}, CurrentMonth=${currentExpiredCount}, LastMonth=${lastMonthExpiredCount}`,
+        );
+        this.logger.debug(
+          `🔍 Date Ranges: CurrentMonth=${DateRangeUtils.toISOString(currentMonth.start)}, LastMonth=${DateRangeUtils.toISOString(lastMonth.start)} to ${DateRangeUtils.toISOString(lastMonth.end)}`,
+        );
+
+        const expiredLicenseStats =
+          DashboardDataTransformer.transformExpiredLicenseStats(
+            totalExpiredCount,
+            currentExpiredCount,
+            lastMonthExpiredCount,
+          );
+
+        this.logger.debug(
+          `🔍 Expired License Stats Result: currentCount=${expiredLicenseStats.currentCount}, currentMonthCount=${expiredLicenseStats.currentMonthCount}, lastMonthCount=${expiredLicenseStats.lastMonthCount}, percentageChange=${expiredLicenseStats.percentageChange}`,
+        );
+
+        const refundStats =
+          DashboardDataTransformer.transformRefundStatsWithAmounts(
+            currentRefundedAmountValue,
+            lastMonthRefundedAmountValue,
+            currentRefundedCountValue,
+            lastMonthRefundedCountValue,
+          );
+
+        this.logger.debug(
+          `🔍 Refund Stats Debug: Raw values - currentAmount=${currentRefundedAmountValue}, lastMonthAmount=${lastMonthRefundedAmountValue}, currentCount=${currentRefundedCountValue}, lastMonthCount=${lastMonthRefundedCountValue}`,
+        );
+        this.logger.debug(
+          `🔍 Refund Stats Result: currentAmount=${refundStats.currentAmount}, lastMonthAmount=${refundStats.lastMonthAmount}, currentCount=${refundStats.currentCount}, lastMonthCount=${refundStats.lastMonthCount}, percentageChange=${refundStats.percentageChange}`,
+        );
+
+        // Debug SQL queries for manual testing
+        this.logger.debug(`\n=== DEBUG SQL QUERIES FOR MANUAL TESTING ===`);
+        this.logger.debug(`Schema: "${schemaName}"`);
+        this.logger.debug(
+          `Current Month Start: ${DateRangeUtils.toISOString(currentMonth.start)}`,
+        );
+        this.logger.debug(
+          `Last Month Start: ${DateRangeUtils.toISOString(lastMonth.start)}`,
+        );
+        this.logger.debug(
+          `Last Month End: ${DateRangeUtils.toISOString(lastMonth.end)}`,
+        );
+        this.logger.debug(
+          `\n-- Query 1: Current Month Refunded Amount (via variant → orderItem → unitPrice) --`,
+        );
+        this.logger
+          .debug(`SELECT COALESCE(SUM(oi."unitPrice"), 0) as total_amount 
+FROM "${schemaName}"."mktLicense" l 
+JOIN "${schemaName}"."mktVariant" v ON l."mktVariantId" = v."id"
+JOIN "${schemaName}"."mktOrderItem" oi ON v."id" = oi."mktVariantId"
+WHERE l."status" = 'REFUND' AND l."updatedAt" >= '${DateRangeUtils.toISOString(currentMonth.start)}';`);
+        this.logger.debug(
+          `\n-- Query 2: Last Month Refunded Amount (via variant → orderItem → unitPrice) --`,
+        );
+        this.logger
+          .debug(`SELECT COALESCE(SUM(oi."unitPrice"), 0) as total_amount 
+FROM "${schemaName}"."mktLicense" l 
+JOIN "${schemaName}"."mktVariant" v ON l."mktVariantId" = v."id"
+JOIN "${schemaName}"."mktOrderItem" oi ON v."id" = oi."mktVariantId"
+WHERE l."status" = 'REFUND' AND l."updatedAt" >= '${DateRangeUtils.toISOString(lastMonth.start)}' AND l."updatedAt" <= '${DateRangeUtils.toISOString(lastMonth.end)}';`);
+        this.logger.debug(`\n-- Query 3: Current Month Refunded Count --`);
+        this.logger.debug(
+          `SELECT COUNT(*) as count FROM "${schemaName}"."mktLicense" WHERE "status" = 'REFUND' AND "updatedAt" >= '${DateRangeUtils.toISOString(currentMonth.start)}';`,
+        );
+        this.logger.debug(`\n-- Query 4: Last Month Refunded Count --`);
+        this.logger.debug(
+          `SELECT COUNT(*) as count FROM "${schemaName}"."mktLicense" WHERE "status" = 'REFUND' AND "updatedAt" >= '${DateRangeUtils.toISOString(lastMonth.start)}' AND "updatedAt" <= '${DateRangeUtils.toISOString(lastMonth.end)}';`,
+        );
+        this.logger.debug(
+          `\n-- Query 5: Debug - All REFUND licenses with details --`,
+        );
+        this.logger
+          .debug(`SELECT l."id", l."name", l."licenseKey", l."status", l."updatedAt", l."mktVariantId", v."name" as variant_name, oi."unitPrice" 
+FROM "${schemaName}"."mktLicense" l 
+LEFT JOIN "${schemaName}"."mktVariant" v ON l."mktVariantId" = v."id"
+LEFT JOIN "${schemaName}"."mktOrderItem" oi ON v."id" = oi."mktVariantId"
+WHERE l."status" = 'REFUND' 
+ORDER BY l."updatedAt" DESC 
+LIMIT 10;`);
+        this.logger.debug(`=== END DEBUG SQL QUERIES ===\n`);
+
+        const expiringStats = DashboardDataTransformer.transformExpiringData(
+          expiringLicensesCount,
+          30,
+        );
+
+        const usageStats = DashboardDataTransformer.transformUsageStats(
+          usageActiveTodayCount,
+          usageActiveThisWeekCount,
+          usageActiveThisMonthCount,
+        );
+
+        // Calculate trial licenses statistics
+        const trialLicenseStats =
+          DashboardDataTransformer.transformLicenseCountStats(
+            trialLicensesCount,
+            currentMonthTrialCount,
+            lastMonthTrialCount,
+          );
+
+        return {
+          totalLicenses: totalLicenseStats,
+          activeLicenses: activeLicenseStats,
+          trialLicenses: trialLicenseStats,
+          expiredLicenses: expiredLicenseStats,
+          refundedAmount: refundStats,
+          expiringInDays: expiringStats,
+          usageStatistics: usageStats,
+        };
+      } catch (error) {
+        retryCount++;
+        this.logger.error(
+          `❌ Attempt ${retryCount} failed for workspace ${workspaceId}:`,
+          {
+            message: error?.message,
+            stack: error?.stack,
+            name: error?.name,
+            code: error?.code,
+          },
+        );
+
+        // Check if it's a connection error
+        if (
+          error?.message?.includes('client is closed') ||
+          error?.message?.includes('connection') ||
+          error?.code === 'CONNECTION_LOST'
+        ) {
+          this.logger.error(
+            '🔌 Database connection error detected. This may be due to connection pooling issues.',
+          );
+        }
+
+        if (retryCount > maxRetries) {
+          this.logger.error(
+            `❌ All ${maxRetries + 1} attempts failed for workspace ${workspaceId}`,
+          );
+
+          return null;
+        }
+
+        // Wait a bit before retrying
+        this.logger.warn(
+          `⏰ Waiting ${retryCount * 1000}ms before retry ${retryCount + 1}/${maxRetries + 1}`,
+        );
+        await new Promise((resolve) => setTimeout(resolve, retryCount * 1000));
+      }
+    }
+
+    return null;
+  }
+
+  private async outputJSON(
+    workspace: Workspace,
+    stats: LicenseStats,
+  ): Promise<void> {
+    const output = {
+      timestamp: new Date().toISOString(),
+      workspace: {
+        id: workspace.id,
+        displayName: workspace.displayName,
+      },
+      statistics: stats,
+    };
+
+    this.logger.log(JSON.stringify(output, null, 2));
+  }
+
+  private async outputTable(
+    workspace: Workspace,
+    stats: LicenseStats,
+    options: DashboardOptions,
+  ): Promise<void> {
+    this.logger.log('\n=== LICENSE DASHBOARD STATISTICS ===\n');
+    this.logger.log(`🏢 Workspace: ${workspace.displayName || workspace.id}`);
+    this.logger.log(`📊 Generated: ${new Date().toLocaleString()}\n`);
+
+    // Use DashboardDataTransformer to format stats for console
+    const formattedStats =
+      DashboardDataTransformer.formatLicenseStatsForConsole(stats);
+
+    // Basic Statistics
+    this.logger.log('📊 1. TỔNG BẢN QUYỀN');
+    this.logger.log(
+      `   Số lượng: ${formattedStats.totalLicenses.count.toLocaleString()}`,
+    );
+    this.logger.log(
+      `   Tháng này: ${formattedStats.totalLicenses.currentMonthCount.toLocaleString()}`,
+    );
+    this.logger.log(
+      `   Tháng trước: ${formattedStats.totalLicenses.lastMonthCount.toLocaleString()}`,
+    );
+    this.logger.log(
+      `   Thay đổi: ${formattedStats.totalLicenses.changeText} so với tháng trước\n`,
+    );
+
+    this.logger.log('🟢 2. ĐANG HOẠT ĐỘNG');
+    this.logger.log(
+      `   Số lượng: ${formattedStats.activeLicenses.count.toLocaleString()}`,
+    );
+    this.logger.log(
+      `   Hoạt động hôm nay: ${formattedStats.activeLicenses.todayCount.toLocaleString()}`,
+    );
+    this.logger.log(
+      `   Hoạt động hôm qua: ${formattedStats.activeLicenses.yesterdayCount.toLocaleString()}`,
+    );
+    this.logger.log(
+      `   Thay đổi hàng ngày: ${formattedStats.activeLicenses.dailyChangeText} so với hôm qua`,
+    );
+    this.logger.log(
+      `   Tỷ lệ: ${formattedStats.activeLicenses.activePercentage}% tổng số license\n`,
+    );
+
+    this.logger.log('🔄 3. SỐ BẢN QUYỀN DÙNG THỬ');
+    this.logger.log(
+      `   Số lượng: ${formattedStats.trialLicenses.count.toLocaleString()}`,
+    );
+    this.logger.log(
+      `   Tháng này: ${formattedStats.trialLicenses.currentMonthCount.toLocaleString()}`,
+    );
+    this.logger.log(
+      `   Tháng trước: ${formattedStats.trialLicenses.lastMonthCount.toLocaleString()}`,
+    );
+    this.logger.log(
+      `   Thay đổi: ${formattedStats.trialLicenses.changeText} so với tháng trước\n`,
+    );
+
+    this.logger.log('❌ 4. BẢN QUYỀN HẾT HẠN');
+    this.logger.log(
+      `   Số lượng: ${formattedStats.expiredLicenses.currentCount.toLocaleString()}`,
+    );
+    this.logger.log(
+      `   Tháng này: ${formattedStats.expiredLicenses.currentMonthCount.toLocaleString()}`,
+    );
+    this.logger.log(
+      `   Tháng trước: ${formattedStats.expiredLicenses.lastMonthCount.toLocaleString()}`,
+    );
+    this.logger.log(
+      `   Thay đổi: ${formattedStats.expiredLicenses.changeText} so với tháng trước\n`,
+    );
+
+    this.logger.log('💰 5. ĐÃ HOÀN TIỀN');
+    this.logger.log('	Tháng này: ');
+    this.logger.log(
+      `		Số lượng: ${formattedStats.refundedAmount.currentCount.toLocaleString()}`,
+    );
+    this.logger.log(
+      `		Số tiền (VND): ${Math.round(formattedStats.refundedAmount.currentAmount).toLocaleString('vi-VN')}`,
+    );
+    this.logger.log('	Tháng Trước:');
+    this.logger.log(
+      `		Số lượng: ${formattedStats.refundedAmount.lastMonthCount.toLocaleString()}`,
+    );
+    this.logger.log(
+      `		Số tiền (VND): ${Math.round(formattedStats.refundedAmount.lastMonthAmount).toLocaleString('vi-VN')}`,
+    );
+    this.logger.log('	Thay đổi so với tháng trước:');
+    this.logger.log(
+      `		Số lượng: ${formattedStats.refundedAmount.currentCount - formattedStats.refundedAmount.lastMonthCount >= 0 ? '+' : ''}${formattedStats.refundedAmount.currentCount - formattedStats.refundedAmount.lastMonthCount}`,
+    );
+    this.logger.log(
+      `		Số tiền chênh lệch (VND): ${formattedStats.refundedAmount.currentAmount - formattedStats.refundedAmount.lastMonthAmount >= 0 ? '+' : ''}${Math.round(formattedStats.refundedAmount.currentAmount - formattedStats.refundedAmount.lastMonthAmount).toLocaleString('vi-VN')}`,
+    );
+    this.logger.log(
+      `		% chênh lệch: ${formattedStats.refundedAmount.changeText}\n`,
+    );
+
+    this.logger.log('📊 6. TÌNH HÌNH HIỆN TẠI');
+    this.logger.log('   📍 License sắp hết hạn:');
+    this.logger.log(
+      `   - Số lượng: ${formattedStats.expiringInDays.count.toLocaleString()}`,
+    );
+    this.logger.log(
+      `   - Trong ${formattedStats.expiringInDays.daysToExpire} ngày tới\n`,
+    );
+
+    this.logger.log('   📈 Tình hình sử dụng:');
+    this.logger.log(
+      `   - Hoạt động hôm nay: ${formattedStats.usageStatistics.activeToday.toLocaleString()}`,
+    );
+    this.logger.log(
+      `   - Hoạt động tuần này: ${formattedStats.usageStatistics.activeThisWeek.toLocaleString()}`,
+    );
+    this.logger.log(
+      `   - Hoạt động tháng này: ${formattedStats.usageStatistics.activeThisMonth.toLocaleString()}\n`,
+    );
+
+    if (options.detailed && stats.expiringInDays.count > 0) {
+      this.logger.log('📋 CHI TIẾT LICENSE SẮP HẾT HẠN:');
+      await this.outputExpiringLicenseDetails(workspace.id);
+    }
+  }
+
+  private async outputExpiringLicenseDetails(
+    workspaceId: string,
+  ): Promise<void> {
+    try {
+      this.logger.debug(
+        `🔌 Connecting for expiring license details for workspace ${workspaceId}`,
+      );
+      const dataSource =
+        await this.workspaceDataSourceService.connectToMainDataSource();
+
+      if (!dataSource) {
+        this.logger.log('   (Could not connect to database)');
+
+        return;
+      }
+
+      if (!(await this.validateConnection(dataSource))) {
+        this.logger.log('   (Database connection validation failed)');
+
+        return;
+      }
+
+      const schemaName = getWorkspaceSchemaName(workspaceId);
+      const thirtyDaysFromNow = new Date();
+
+      thirtyDaysFromNow.setDate(thirtyDaysFromNow.getDate() + 30);
+
+      this.logger.debug(
+        `🔍 Querying expiring licenses in schema: ${schemaName}`,
+      );
+
+      // Use direct query instead of query builder for consistency
+      const expiringLicenses = await dataSource.query(
+        `SELECT 
+          "licenseKey" as license_licenseKey,
+          "name" as license_name, 
+          "expiresAt" as license_expiresAt
+         FROM "${schemaName}"."mktLicense" 
+         WHERE "expiresAt" IS NOT NULL 
+           AND "expiresAt" <= $1 
+           AND "expiresAt" > $2 
+           AND "deletedAt" IS NULL 
+         ORDER BY "expiresAt" ASC 
+         LIMIT 10`,
+        [thirtyDaysFromNow.toISOString(), new Date().toISOString()],
+      );
+
+      this.logger.debug(
+        `✅ Expiring licenses query completed: ${expiringLicenses?.length || 0} results`,
+      );
+
+      if (expiringLicenses.length > 0) {
+        expiringLicenses.forEach(
+          (
+            license: {
+              license_expiresAt: string;
+              license_name: string;
+              license_licenseKey: string;
+            },
+            index: number,
+          ) => {
+            const expiryDate = new Date(license.license_expiresAt);
+            const daysUntilExpiry =
+              DashboardDataTransformer.calculateDaysUntilExpiry(expiryDate);
+            const displayName =
+              DashboardDataTransformer.formatLicenseDisplayName(
+                license.license_name,
+                license.license_licenseKey,
+              );
+
+            this.logger.log(
+              `   ${index + 1}. ${displayName} - expires in ${daysUntilExpiry} days`,
+            );
+          },
+        );
+
+        if (expiringLicenses.length >= 10) {
+          this.logger.log('   ... (showing first 10 licenses)');
+        }
+      } else {
+        this.logger.log('   (No licenses expiring in the next 30 days)');
+      }
+    } catch (error) {
+      this.logger.error('❌ Error getting expiring license details:', {
+        message: error?.message,
+        stack: error?.stack,
+        workspaceId,
+      });
+
+      if (error?.message?.includes('client is closed')) {
+        this.logger.error(
+          '🔌 Client closed error in outputExpiringLicenseDetails',
+        );
+      }
+
+      this.logger.log('   (Could not retrieve expiring licenses details)');
+    }
+  }
+
+  private async saveLicenseStatsToReport(
+    workspaceId: string,
+    stats: LicenseStats,
+  ): Promise<void> {
+    try {
+      this.logger.debug(
+        `📊 Starting to save license statistics to report for workspace: ${workspaceId}`,
+      );
+
+      // Get the repository for mktReport in the workspace
+      const mktReportRepository =
+        await this.twentyORMGlobalManager.getRepositoryForWorkspace(
+          workspaceId,
+          MktReportWorkspaceEntity,
+          {
+            shouldBypassPermissionChecks: true,
+          },
+        );
+
+      this.logger.debug(`✅ Repository obtained for workspace: ${workspaceId}`);
+
+      // Use DashboardDataTransformer to create report data
+      const reportData = DashboardDataTransformer.createLicenseReportData(
+        workspaceId,
+        stats as LicenseStats,
+        '1.0',
+      );
+
+      this.logger.debug(`💾 Saving report data for workspace: ${workspaceId}`);
+      const savedReport = await mktReportRepository.save(reportData);
+
+      this.logger.debug(
+        `✅ Report saved with ID: ${savedReport?.id || 'unknown'}`,
+      );
+
+      this.logger.log(
+        `📊 License statistics saved to mktReport for workspace: ${workspaceId}`,
+      );
+    } catch (error) {
+      this.logger.error(
+        `❌ Failed to save license statistics to report for workspace ${workspaceId}:`,
+        {
+          message: error?.message,
+          stack: error?.stack,
+          name: error?.name,
+        },
+      );
+
+      // Don't throw the error, just log it so the main process continues
+      if (error?.message?.includes('client is closed')) {
+        this.logger.error(
+          '🔌 Client closed error detected in saveLicenseStatsToReport',
+        );
+      }
+    }
+  }
+}

--- a/packages/twenty-server/src/mkt-core/license/crons/commands/mkt-license-dashboard-stats.cron.command.ts
+++ b/packages/twenty-server/src/mkt-core/license/crons/commands/mkt-license-dashboard-stats.cron.command.ts
@@ -1,0 +1,121 @@
+import { Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+import { Command, CommandRunner, Option } from 'nest-commander';
+
+import { InjectMessageQueue } from 'src/engine/core-modules/message-queue/decorators/message-queue.decorator';
+import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queue.constants';
+import { MessageQueueService } from 'src/engine/core-modules/message-queue/services/message-queue.service';
+import {
+  MKT_LICENSE_DASHBOARD_STATS_CRON_PATTERN,
+  MktLicenseDashboardStatsCronOptions,
+  MktLicenseDashboardStatsJobData,
+} from 'src/mkt-core/license/crons/mkt-license-dashboard-stats.cron.constants';
+
+@Command({
+  name: 'cron:license:dashboard-stats',
+  description: 'Starts cron jobs for license dashboard statistics generation',
+})
+export class MktLicenseDashboardStatsCronCommand extends CommandRunner {
+  private readonly logger = new Logger(
+    MktLicenseDashboardStatsCronCommand.name,
+  );
+
+  constructor(
+    @InjectMessageQueue(MessageQueue.cronQueue)
+    private readonly messageQueueService: MessageQueueService,
+    private readonly configService: ConfigService,
+  ) {
+    super();
+  }
+
+  @Option({
+    flags: '-w, --workspace-ids [workspace_ids]',
+    description:
+      'Comma-separated list of workspace IDs (or use env variable MKT_LICENSE_STATS_WORKSPACE_IDS)',
+  })
+  parseWorkspaceIds(value: string): string {
+    return value;
+  }
+
+  @Option({
+    flags: '-c, --cron-pattern [cron_pattern]',
+    description:
+      'Cron pattern for scheduling (or use env variable MKT_LICENSE_STATS_CRON_PATTERN)',
+  })
+  parseCronPattern(value: string): string {
+    return value;
+  }
+
+  async run(
+    passedParams: string[],
+    options?: MktLicenseDashboardStatsCronOptions,
+  ): Promise<void> {
+    // Lấy workspace IDs từ options hoặc env
+    const workspaceIdsString =
+      options?.workspaceIds ||
+      this.configService.get<string>('MKT_LICENSE_STATS_WORKSPACE_IDS');
+
+    if (!workspaceIdsString) {
+      this.logger.error(
+        'No workspace IDs provided. Please specify --workspace-ids or set MKT_LICENSE_STATS_WORKSPACE_IDS in .env',
+      );
+
+      return;
+    }
+
+    // Lấy cron pattern từ options hoặc env (mặc định là hàng ngày lúc 2:00 AM)
+    const cronPattern =
+      options?.cronPattern ||
+      this.configService.get<string>('MKT_LICENSE_STATS_CRON_PATTERN') ||
+      MKT_LICENSE_DASHBOARD_STATS_CRON_PATTERN;
+
+    // Parse workspace IDs
+    const workspaceIds = workspaceIdsString
+      .split(',')
+      .map((id) => id.trim())
+      .filter(Boolean);
+
+    if (workspaceIds.length === 0) {
+      this.logger.error('No valid workspace IDs found');
+
+      return;
+    }
+
+    this.logger.log(
+      `Setting up license dashboard stats cron jobs for ${workspaceIds.length} workspace(s)`,
+    );
+    this.logger.log(`Cron pattern: ${cronPattern}`);
+    this.logger.log(`Workspace IDs: ${workspaceIds.join(', ')}`);
+
+    // Tạo cron job cho từng workspace
+    for (const workspaceId of workspaceIds) {
+      try {
+        const jobData: MktLicenseDashboardStatsJobData = {
+          workspaceId,
+        };
+
+        await this.messageQueueService.addCron({
+          jobName: 'mkt-license-dashboard-stats',
+          data: jobData,
+          options: {
+            repeat: { pattern: cronPattern },
+          },
+        });
+
+        this.logger.log(
+          `Cron job registered successfully for workspace: ${workspaceId}`,
+        );
+      } catch (error) {
+        this.logger.error(
+          `Failed to register cron job for workspace ${workspaceId}:`,
+          error,
+        );
+      }
+    }
+
+    this.logger.log(
+      'All license dashboard stats cron jobs have been registered',
+    );
+  }
+}

--- a/packages/twenty-server/src/mkt-core/license/crons/index.ts
+++ b/packages/twenty-server/src/mkt-core/license/crons/index.ts
@@ -1,0 +1,12 @@
+// Commands
+export { MktLicenseDashboardStatsCronCommand } from './commands/mkt-license-dashboard-stats.cron.command';
+
+// Jobs
+export { MktLicenseDashboardStatsCronJob } from './jobs/mkt-license-dashboard-stats.cron.job';
+
+// Constants and Types
+export {
+  MKT_LICENSE_DASHBOARD_STATS_CRON_PATTERN,
+  MktLicenseDashboardStatsCronOptions,
+  MktLicenseDashboardStatsJobData,
+} from './mkt-license-dashboard-stats.cron.constants';

--- a/packages/twenty-server/src/mkt-core/license/crons/jobs/mkt-license-dashboard-stats.cron.job.ts
+++ b/packages/twenty-server/src/mkt-core/license/crons/jobs/mkt-license-dashboard-stats.cron.job.ts
@@ -1,0 +1,87 @@
+import { Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { InjectRepository } from '@nestjs/typeorm';
+
+import { Repository } from 'typeorm';
+
+import { SentryCronMonitor } from 'src/engine/core-modules/cron/sentry-cron-monitor.decorator';
+import { ExceptionHandlerService } from 'src/engine/core-modules/exception-handler/exception-handler.service';
+import { Process } from 'src/engine/core-modules/message-queue/decorators/process.decorator';
+import { Processor } from 'src/engine/core-modules/message-queue/decorators/processor.decorator';
+import { MessageQueue } from 'src/engine/core-modules/message-queue/message-queue.constants';
+import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';
+import { MktLicenseDashboardStatsCommand } from 'src/mkt-core/license/commands/mkt-license-dashboard-stats.command';
+import {
+  MKT_LICENSE_DASHBOARD_STATS_CRON_PATTERN,
+  MktLicenseDashboardStatsJobData,
+} from 'src/mkt-core/license/crons/mkt-license-dashboard-stats.cron.constants';
+
+@Processor(MessageQueue.cronQueue)
+export class MktLicenseDashboardStatsCronJob {
+  private readonly logger = new Logger(MktLicenseDashboardStatsCronJob.name);
+
+  constructor(
+    @InjectRepository(Workspace, 'core')
+    private readonly workspaceRepository: Repository<Workspace>,
+    private readonly configService: ConfigService,
+    private readonly exceptionHandlerService: ExceptionHandlerService,
+    private readonly mktLicenseDashboardStatsCommand: MktLicenseDashboardStatsCommand,
+  ) {
+    this.logger.log('🚀 MktLicenseDashboardStatsCronJob processor initialized');
+  }
+
+  @Process('mkt-license-dashboard-stats')
+  @SentryCronMonitor(
+    'mkt-license-dashboard-stats',
+    MKT_LICENSE_DASHBOARD_STATS_CRON_PATTERN,
+  )
+  async handle(data: MktLicenseDashboardStatsJobData): Promise<void> {
+    this.logger.log(
+      '🔥 CRON JOB RECEIVED! Processing mkt-license-dashboard-stats',
+    );
+    this.logger.log(`📋 Job data received: ${JSON.stringify(data)}`);
+
+    const { workspaceId } = data;
+
+    try {
+      this.logger.log(
+        `🚀 Starting license dashboard stats generation for workspace: ${workspaceId}`,
+      );
+
+      // Kiểm tra workspace có tồn tại không
+      const workspace = await this.workspaceRepository.findOne({
+        where: { id: workspaceId },
+      });
+
+      if (!workspace) {
+        this.logger.warn(
+          `Workspace ${workspaceId} not found, skipping stats generation`,
+        );
+
+        return;
+      }
+
+      // Chạy command với workspace ID
+      await this.mktLicenseDashboardStatsCommand.run([], {
+        workspaceId,
+        format: 'json',
+        detailed: true,
+      });
+
+      this.logger.log(
+        `License dashboard stats generated successfully for workspace: ${workspaceId}`,
+      );
+    } catch (error) {
+      this.logger.error(
+        `Failed to generate license dashboard stats for workspace ${workspaceId}:`,
+        error,
+      );
+
+      this.exceptionHandlerService.captureExceptions([error], {
+        workspace: {
+          id: workspaceId,
+        },
+      });
+    }
+  }
+}

--- a/packages/twenty-server/src/mkt-core/license/crons/mkt-license-dashboard-stats.cron.constants.ts
+++ b/packages/twenty-server/src/mkt-core/license/crons/mkt-license-dashboard-stats.cron.constants.ts
@@ -1,0 +1,10 @@
+export const MKT_LICENSE_DASHBOARD_STATS_CRON_PATTERN = '0 2 * * *'; // Hàng ngày lúc 2:00 AM
+
+export interface MktLicenseDashboardStatsJobData {
+  workspaceId: string;
+}
+
+export interface MktLicenseDashboardStatsCronOptions {
+  workspaceIds?: string;
+  cronPattern?: string;
+}

--- a/packages/twenty-server/src/mkt-core/license/integration/mkt-license-csv-export.controller.ts
+++ b/packages/twenty-server/src/mkt-core/license/integration/mkt-license-csv-export.controller.ts
@@ -1,0 +1,179 @@
+import {
+  Controller,
+  Get,
+  HttpException,
+  HttpStatus,
+  Query,
+  Req,
+  Res,
+  UseGuards,
+} from '@nestjs/common';
+
+import { Request, Response } from 'express';
+
+import { JwtAuthGuard } from 'src/engine/guards/jwt-auth.guard';
+import { UserAuthGuard } from 'src/engine/guards/user-auth.guard';
+
+import { MktLicenseCsvExportService } from './mkt-license-csv-export.service';
+
+@Controller('api/admin/license')
+export class MktLicenseCsvExportController {
+  constructor(private readonly csvExportService: MktLicenseCsvExportService) {}
+
+  private extractWorkspaceIdFromRequest(req: Request): string | undefined {
+    try {
+      // Extract from JWT token in Authorization header
+      const token = req.headers.authorization?.replace('Bearer ', '');
+
+      if (token) {
+        // Decode JWT token (base64 decode the payload)
+        const payload = JSON.parse(
+          Buffer.from(token.split('.')[1], 'base64').toString(),
+        );
+
+        return payload.workspaceId;
+      }
+    } catch (error) {
+      // Use a proper logger instead of console
+      // This is a temporary console replacement that should be replaced with proper logging
+      // eslint-disable-next-line no-console
+      console.error('Failed to extract workspaceId from token:', error);
+    }
+
+    return undefined;
+  }
+
+  @UseGuards(JwtAuthGuard, UserAuthGuard)
+  @Get('export-dashboard-csv')
+  async exportDashboardCsv(
+    @Query('reportType') reportType = 'license-dashboard',
+    @Query('workspaceId') workspaceId: string,
+    @Req() req: Request,
+    @Res() res: Response,
+  ) {
+    try {
+      if (!reportType) {
+        throw new HttpException(
+          'Report type is required',
+          HttpStatus.BAD_REQUEST,
+        );
+      }
+
+      // Extract workspaceId from JWT token if not provided in query
+      const targetWorkspaceId =
+        workspaceId || this.extractWorkspaceIdFromRequest(req);
+
+      const exportData = await this.csvExportService.exportLicenseDashboardCsv(
+        reportType,
+        targetWorkspaceId,
+      );
+
+      if (!exportData) {
+        throw new HttpException(
+          'Failed to generate export data',
+          HttpStatus.INTERNAL_SERVER_ERROR,
+        );
+      }
+
+      const fileName = `license-dashboard-${new Date().toISOString().split('T')[0]}.csv`;
+
+      res.setHeader('Content-Type', 'text/csv');
+      res.setHeader(
+        'Content-Disposition',
+        `attachment; filename="${fileName}"`,
+      );
+      res.setHeader('Cache-Control', 'no-cache');
+      res.setHeader('Pragma', 'no-cache');
+
+      res.send(exportData.data);
+    } catch (error) {
+      throw new HttpException(
+        `Failed to export CSV: ${error.message}`,
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+  }
+
+  @UseGuards(JwtAuthGuard, UserAuthGuard)
+  @Get('dashboard-report')
+  async getDashboardReport(
+    @Query('reportType') reportType = 'license-dashboard',
+    @Query('workspaceId') workspaceId: string,
+    @Req() req: Request,
+  ) {
+    try {
+      if (!reportType) {
+        throw new HttpException(
+          'Report type is required',
+          HttpStatus.BAD_REQUEST,
+        );
+      }
+
+      const targetWorkspaceId =
+        workspaceId || this.extractWorkspaceIdFromRequest(req);
+
+      const exportData = await this.csvExportService.exportLicenseDashboardCsv(
+        reportType,
+        targetWorkspaceId,
+      );
+
+      if (!exportData) {
+        throw new HttpException(
+          'Failed to generate export data',
+          HttpStatus.INTERNAL_SERVER_ERROR,
+        );
+      }
+      const report = this.csvExportService.generateDashboardReport(
+        exportData.metadata,
+      );
+
+      return {
+        reportType: exportData.reportType,
+        //workspaceName: exportData.workspaceName,
+        generatedAt: exportData.generatedAt,
+        report,
+        statistics: exportData.metadata,
+      };
+    } catch (error) {
+      throw new HttpException(
+        `Failed to generate report: ${error.message}`,
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+  }
+
+  @UseGuards(JwtAuthGuard, UserAuthGuard)
+  @Get('export-statistics-json')
+  async exportStatisticsJson(
+    @Query('reportType') reportType = 'license-dashboard',
+    @Query('workspaceId') workspaceId: string,
+    @Req() req: Request,
+  ) {
+    try {
+      if (!reportType) {
+        throw new HttpException(
+          'Report type is required',
+          HttpStatus.BAD_REQUEST,
+        );
+      }
+
+      const targetWorkspaceId =
+        workspaceId || this.extractWorkspaceIdFromRequest(req);
+
+      const exportData = await this.csvExportService.exportLicenseDashboardCsv(
+        reportType,
+        targetWorkspaceId,
+      );
+
+      return {
+        success: true,
+        data: exportData,
+      };
+    } catch (error) {
+      throw new HttpException(
+        `Failed to export statistics: ${error.message}`,
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+  }
+}

--- a/packages/twenty-server/src/mkt-core/license/integration/mkt-license-csv-export.service.ts
+++ b/packages/twenty-server/src/mkt-core/license/integration/mkt-license-csv-export.service.ts
@@ -1,0 +1,685 @@
+import { Injectable, Logger } from '@nestjs/common';
+
+import { ScopedWorkspaceContextFactory } from 'src/engine/twenty-orm/factories/scoped-workspace-context.factory';
+import { TwentyORMGlobalManager } from 'src/engine/twenty-orm/twenty-orm-global.manager';
+import { MKT_LICENSE_STATUS } from 'src/mkt-core/license/license.constants';
+import { MktLicenseWorkspaceEntity } from 'src/mkt-core/license/mkt-license.workspace-entity';
+import { MktReportWorkspaceEntity } from 'src/mkt-core/report/objects/mkt-report.workspace-entity';
+
+export interface ReportMetadataStatistics {
+  totalLicenses: {
+    count: number;
+    lastMonthCount: number;
+    percentageChange: number;
+    currentMonthCount: number;
+  };
+  trialLicenses: {
+    count: number;
+    currentMonthCount: number;
+    lastMonthCount: number;
+    percentageChange: number;
+  };
+  activeLicenses: {
+    count: number;
+    todayCount: number;
+    dailyChange: number;
+    yesterdayCount: number;
+  };
+  expiringInDays: {
+    count: number;
+    daysToExpire: number;
+  };
+  refundedAmount: {
+    currentAmount: number;
+    lastMonthAmount: number;
+    currentCount: number;
+    lastMonthCount: number;
+    percentageChange: number;
+  };
+  expiredLicenses: {
+    currentCount: number;
+    lastMonthCount: number;
+    percentageChange: number;
+  };
+  usageStatistics: {
+    activeToday: number;
+    activeThisWeek: number;
+    activeThisMonth: number;
+  };
+}
+
+export interface ReportMetadata {
+  statistics: ReportMetadataStatistics;
+  generatedAt: string;
+  workspaceId: string;
+  reportVersion: string;
+}
+
+export interface LicenseDashboardStatistics {
+  //workspaceName: string;
+  generatedAt: string;
+  totalLicenses: {
+    count: number;
+    thisMonth: number;
+    lastMonth: number;
+    changePercentage: number;
+  };
+  activeLicenses: {
+    count: number;
+    activeToday: number;
+    activeYesterday: number;
+    dailyChange: number;
+    percentage: number;
+  };
+  trialLicenses: {
+    count: number;
+    thisMonth: number;
+    lastMonth: number;
+    changePercentage: number;
+  };
+  expiredLicenses: {
+    count: number;
+    thisMonth: number;
+    lastMonth: number;
+    changePercentage: number;
+  };
+  refundedAmount: {
+    amount: number;
+    count: number;
+    thisMonth: number;
+    lastMonth: number;
+    thisMonthAmount: number;
+    lastMonthAmount: number;
+    changePercentage: number;
+  };
+  currentSituation: {
+    expiringSoon: number;
+    activeToday: number;
+    activeThisWeek: number;
+    activeThisMonth: number;
+  };
+}
+
+export interface CsvExportData {
+  reportType: string;
+  // workspaceName: string;
+  generatedAt: string;
+  data: string; // CSV formatted string
+  metadata: LicenseDashboardStatistics;
+}
+
+@Injectable()
+export class MktLicenseCsvExportService {
+  private readonly logger = new Logger(MktLicenseCsvExportService.name);
+
+  constructor(
+    private readonly twentyORMGlobalManager: TwentyORMGlobalManager,
+    private readonly scopedWorkspaceContextFactory: ScopedWorkspaceContextFactory,
+  ) {}
+
+  async exportLicenseDashboardCsv(
+    reportType: string,
+    workspaceId?: string,
+  ): Promise<CsvExportData | null> {
+    let targetWorkspaceId = workspaceId;
+
+    if (!targetWorkspaceId) {
+      try {
+        const context = this.scopedWorkspaceContextFactory.create();
+
+        targetWorkspaceId = context?.workspaceId || undefined;
+      } catch (error) {
+        this.logger.error('Failed to get workspace context', error);
+      }
+    }
+
+    if (!targetWorkspaceId) {
+      throw new Error(
+        'Workspace ID not found. Please provide workspaceId parameter or ensure proper authentication context.',
+      );
+    }
+
+    try {
+      // Get latest report data
+      const reportData = await this.getLatestReportData(
+        targetWorkspaceId,
+        reportType,
+      );
+
+      if (!reportData) return null;
+
+      // Get license statistics from report data
+      const statistics = this.mapReportDataToStatistics(
+        reportData.metadata as unknown as ReportMetadata,
+        targetWorkspaceId,
+      );
+
+      this.logger.log(
+        `Generated statistics for workspace ${targetWorkspaceId}: ${JSON.stringify(
+          statistics,
+        )}`,
+      );
+      // Generate CSV content
+      const csvContent = this.generateCsvContent(statistics);
+
+      return {
+        reportType,
+        //workspaceName: statistics.workspaceName,
+        generatedAt: statistics.generatedAt,
+        data: csvContent,
+        metadata: statistics,
+      };
+    } catch (error) {
+      this.logger.error(
+        `Failed to export CSV for report type: ${reportType}`,
+        error,
+      );
+      throw error;
+    }
+  }
+
+  private async getLatestReportData(
+    workspaceId: string,
+    reportType: string,
+  ): Promise<MktReportWorkspaceEntity | null> {
+    const reportRepository =
+      await this.twentyORMGlobalManager.getRepositoryForWorkspace<MktReportWorkspaceEntity>(
+        workspaceId,
+        'mktReport',
+        { shouldBypassPermissionChecks: true },
+      );
+
+    return await reportRepository.findOne({
+      where: { reportType },
+      order: { createdAt: 'DESC' },
+    });
+  }
+
+  private async generateLicenseStatistics(
+    workspaceId: string,
+  ): Promise<LicenseDashboardStatistics> {
+    const licenseRepository =
+      await this.twentyORMGlobalManager.getRepositoryForWorkspace<MktLicenseWorkspaceEntity>(
+        workspaceId,
+        'mktLicense',
+        { shouldBypassPermissionChecks: true },
+      );
+
+    const now = new Date();
+    const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+    const yesterday = new Date(today);
+
+    yesterday.setDate(yesterday.getDate() - 1);
+
+    const thisMonthStart = new Date(now.getFullYear(), now.getMonth(), 1);
+    const lastMonthStart = new Date(now.getFullYear(), now.getMonth() - 1, 1);
+    const lastMonthEnd = new Date(thisMonthStart);
+
+    lastMonthEnd.setDate(lastMonthEnd.getDate() - 1);
+
+    const thisWeekStart = new Date(today);
+
+    thisWeekStart.setDate(thisWeekStart.getDate() - today.getDay());
+
+    const next30Days = new Date(now);
+
+    next30Days.setDate(next30Days.getDate() + 30);
+
+    // Get all licenses
+    const allLicenses = await licenseRepository.find();
+
+    // Calculate statistics
+    const totalCount = allLicenses.length;
+    const thisMonthCount = allLicenses.filter(
+      (l) => l.createdAt && new Date(l.createdAt) >= thisMonthStart,
+    ).length;
+    const lastMonthCount = allLicenses.filter(
+      (l) =>
+        l.createdAt &&
+        new Date(l.createdAt) >= lastMonthStart &&
+        new Date(l.createdAt) <= lastMonthEnd,
+    ).length;
+
+    const activeLicenses = allLicenses.filter(
+      (l) => l.status === MKT_LICENSE_STATUS.ACTIVE,
+    );
+    const activeCount = activeLicenses.length;
+
+    const activeToday = activeLicenses.filter(
+      (l) => l.lastLoginAt && new Date(l.lastLoginAt) >= today,
+    ).length;
+
+    const activeYesterday = activeLicenses.filter(
+      (l) =>
+        l.lastLoginAt &&
+        new Date(l.lastLoginAt) >= yesterday &&
+        new Date(l.lastLoginAt) < today,
+    ).length;
+
+    const activeThisWeek = activeLicenses.filter(
+      (l) => l.lastLoginAt && new Date(l.lastLoginAt) >= thisWeekStart,
+    ).length;
+
+    const activeThisMonth = activeLicenses.filter(
+      (l) => l.lastLoginAt && new Date(l.lastLoginAt) >= thisMonthStart,
+    ).length;
+
+    const trialCount = allLicenses.filter(
+      (l) => l.status === MKT_LICENSE_STATUS.TRIAL,
+    ).length;
+
+    // Calculate expired licenses
+    const expiredCount = allLicenses.filter(
+      (l) => l.status === MKT_LICENSE_STATUS.EXPIRED,
+    ).length;
+
+    // Calculate expired licenses for this month (licenses that expired this month by expiresAt)
+    const thisMonthExpiredCount = allLicenses.filter(
+      (l) =>
+        l.status === MKT_LICENSE_STATUS.EXPIRED &&
+        l.expiresAt &&
+        new Date(l.expiresAt) >= thisMonthStart &&
+        new Date(l.expiresAt) <
+          new Date(
+            thisMonthStart.getFullYear(),
+            thisMonthStart.getMonth() + 1,
+            1,
+          ),
+    ).length;
+
+    // Calculate expired licenses for last month (licenses that expired last month by expiresAt)
+    const lastMonthExpiredCount = allLicenses.filter(
+      (l) =>
+        l.status === MKT_LICENSE_STATUS.EXPIRED &&
+        l.expiresAt &&
+        new Date(l.expiresAt) >= lastMonthStart &&
+        new Date(l.expiresAt) < thisMonthStart,
+    ).length;
+
+    const expiringSoon = allLicenses.filter(
+      (l) =>
+        l.expiresAt &&
+        new Date(l.expiresAt) <= next30Days &&
+        new Date(l.expiresAt) > now,
+    ).length;
+
+    // Calculate percentages
+    const totalChangePercentage =
+      lastMonthCount > 0
+        ? ((thisMonthCount - lastMonthCount) / lastMonthCount) * 100
+        : thisMonthCount > 0
+          ? 100
+          : 0;
+
+    const activePercentage =
+      totalCount > 0 ? (activeCount / totalCount) * 100 : 0;
+    const dailyChange = activeToday - activeYesterday;
+
+    // Calculate expired licenses percentage change
+    const expiredChangePercentage =
+      lastMonthExpiredCount > 0
+        ? ((thisMonthExpiredCount - lastMonthExpiredCount) /
+            lastMonthExpiredCount) *
+          100
+        : thisMonthExpiredCount > 0
+          ? 100
+          : 0;
+
+    // Calculate refunded amounts for current month
+    const refundedLicensesThisMonth = allLicenses.filter(
+      (l) =>
+        l.status === MKT_LICENSE_STATUS.REFUND &&
+        l.updatedAt &&
+        new Date(l.updatedAt) >= thisMonthStart,
+    );
+
+    // Calculate refunded amounts for last month
+    const refundedLicensesLastMonth = allLicenses.filter(
+      (l) =>
+        l.status === MKT_LICENSE_STATUS.REFUND &&
+        l.updatedAt &&
+        new Date(l.updatedAt) >= lastMonthStart &&
+        new Date(l.updatedAt) <= lastMonthEnd,
+    );
+
+    // NOTE: This is mock data calculation.
+    // Real data should come from command using: license → variant → orderItem → unitPrice
+    // For fallback/mock purposes only, use average amount per license
+    const averageRefundAmount = 14450000; // Average VND amount based on typical license prices
+    const thisMonthRefundedAmount =
+      refundedLicensesThisMonth.length * averageRefundAmount;
+    const lastMonthRefundedAmount =
+      refundedLicensesLastMonth.length * averageRefundAmount;
+
+    // Calculate refunded amount percentage change
+    const refundedChangePercentage =
+      lastMonthRefundedAmount > 0
+        ? ((thisMonthRefundedAmount - lastMonthRefundedAmount) /
+            lastMonthRefundedAmount) *
+          100
+        : thisMonthRefundedAmount > 0
+          ? 100
+          : 0;
+
+    return {
+      //workspaceName: 'YCombinator', // This should come from workspace data
+      generatedAt: now.toLocaleString('vi-VN', {
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+        hour: '2-digit',
+        minute: '2-digit',
+        second: '2-digit',
+        hour12: false,
+      }),
+      totalLicenses: {
+        count: totalCount,
+        thisMonth: thisMonthCount,
+        lastMonth: lastMonthCount,
+        changePercentage: totalChangePercentage,
+      },
+      activeLicenses: {
+        count: activeCount,
+        activeToday,
+        activeYesterday,
+        dailyChange,
+        percentage: activePercentage,
+      },
+      trialLicenses: {
+        count: trialCount,
+        thisMonth: 0, // TODO: Calculate this month trial count
+        lastMonth: 0, // TODO: Calculate last month trial count
+        changePercentage: 100, // Mock data
+      },
+      expiredLicenses: {
+        count: expiredCount,
+        thisMonth: thisMonthExpiredCount,
+        lastMonth: lastMonthExpiredCount,
+        changePercentage: expiredChangePercentage,
+      },
+      refundedAmount: {
+        amount: thisMonthRefundedAmount,
+        count:
+          refundedLicensesThisMonth.length + refundedLicensesLastMonth.length, // Total count
+        thisMonth: refundedLicensesThisMonth.length,
+        lastMonth: refundedLicensesLastMonth.length,
+        thisMonthAmount: thisMonthRefundedAmount,
+        lastMonthAmount: lastMonthRefundedAmount,
+        changePercentage: refundedChangePercentage,
+      },
+      currentSituation: {
+        expiringSoon,
+        activeToday,
+        activeThisWeek,
+        activeThisMonth,
+      },
+    };
+  }
+
+  private mapReportDataToStatistics(
+    metadata: ReportMetadata,
+    _workspaceId: string,
+  ): LicenseDashboardStatistics {
+    const stats = metadata?.statistics;
+    const now = new Date();
+
+    if (!stats) {
+      throw new Error('No statistics found in report metadata');
+    }
+
+    return {
+      //workspaceName: 'YCombinator', // This should come from workspace data
+      generatedAt: metadata?.generatedAt
+        ? new Date(metadata.generatedAt).toLocaleString('vi-VN', {
+            year: 'numeric',
+            month: '2-digit',
+            day: '2-digit',
+            hour: '2-digit',
+            minute: '2-digit',
+            second: '2-digit',
+            hour12: false,
+          })
+        : now.toLocaleString('vi-VN', {
+            year: 'numeric',
+            month: '2-digit',
+            day: '2-digit',
+            hour: '2-digit',
+            minute: '2-digit',
+            second: '2-digit',
+            hour12: false,
+          }),
+      totalLicenses: {
+        count: stats.totalLicenses?.count || 0,
+        thisMonth: stats.totalLicenses?.currentMonthCount || 0,
+        lastMonth: stats.totalLicenses?.lastMonthCount || 0,
+        changePercentage: stats.totalLicenses?.percentageChange || 0,
+      },
+      activeLicenses: {
+        count: stats.activeLicenses?.count || 0,
+        activeToday: stats.activeLicenses?.todayCount || 0,
+        activeYesterday: stats.activeLicenses?.yesterdayCount || 0,
+        dailyChange: stats.activeLicenses?.dailyChange || 0,
+        percentage:
+          stats.activeLicenses?.count && stats.totalLicenses?.count
+            ? (stats.activeLicenses.count / stats.totalLicenses.count) * 100
+            : 0,
+      },
+      trialLicenses: {
+        count: stats.trialLicenses?.count || 0,
+        thisMonth: stats.trialLicenses?.currentMonthCount || 0,
+        lastMonth: stats.trialLicenses?.lastMonthCount || 0,
+        changePercentage: stats.trialLicenses?.percentageChange || 0,
+      },
+      expiredLicenses: {
+        count: stats.expiredLicenses?.currentCount || 0,
+        thisMonth: 0, // TODO: This should come from report metadata
+        lastMonth: stats.expiredLicenses?.lastMonthCount || 0,
+        changePercentage: stats.expiredLicenses?.percentageChange || 0,
+      },
+      refundedAmount: {
+        amount: stats.refundedAmount?.currentAmount || 0,
+        count: stats.refundedAmount?.currentCount || 0,
+        thisMonth: stats.refundedAmount?.currentCount || 0,
+        lastMonth: stats.refundedAmount?.lastMonthCount || 0,
+        thisMonthAmount: stats.refundedAmount?.currentAmount || 0,
+        lastMonthAmount: stats.refundedAmount?.lastMonthAmount || 0,
+        changePercentage: stats.refundedAmount?.percentageChange || 0,
+      },
+      currentSituation: {
+        expiringSoon: stats.expiringInDays?.count || 0,
+        activeToday:
+          stats.usageStatistics?.activeToday ||
+          stats.activeLicenses?.todayCount ||
+          0,
+        activeThisWeek: stats.usageStatistics?.activeThisWeek || 0,
+        activeThisMonth: stats.usageStatistics?.activeThisMonth || 0,
+      },
+    };
+  }
+
+  private generateCsvContent(statistics: LicenseDashboardStatistics): string {
+    const csvRows = [
+      // Header
+      ['Chỉ số', 'Giá trị', 'Thông tin bổ sung'],
+
+      // Basic info
+      //['Không gian làm việc', statistics.workspaceName, ''],
+      ['Thời điểm tạo', statistics.generatedAt, ''],
+      ['', '', ''], // Empty row for separation
+
+      // Total licenses
+      ['Tổng số license', '', ''],
+      ['Tổng số', statistics.totalLicenses.count.toString(), ''],
+      ['Tháng này', statistics.totalLicenses.thisMonth.toString(), ''],
+      ['Tháng trước', statistics.totalLicenses.lastMonth.toString(), ''],
+      [
+        'Thay đổi %',
+        `${statistics.totalLicenses.changePercentage.toFixed(1)}%`,
+        'so với tháng trước',
+      ],
+      ['', '', ''], // Empty row
+
+      // Active licenses
+      ['Đang hoạt động', '', ''],
+      ['Số lượng', statistics.activeLicenses.count.toString(), ''],
+      [
+        'Hoạt động hôm nay',
+        statistics.activeLicenses.activeToday.toString(),
+        '',
+      ],
+      [
+        'Hoạt động hôm qua',
+        statistics.activeLicenses.activeYesterday.toString(),
+        '',
+      ],
+      [
+        'Thay đổi hàng ngày',
+        statistics.activeLicenses.dailyChange.toString(),
+        'so với hôm qua',
+      ],
+      ['Tỷ lệ', `${statistics.activeLicenses.percentage.toFixed(2)}%`, ''],
+      ['', '', ''], // Empty row
+
+      // Trial licenses
+      ['BẢN QUYỀN DÙNG THỬ', '', ''],
+      ['Số lượng', statistics.trialLicenses.count.toString(), ''],
+      ['Tháng này', statistics.trialLicenses.thisMonth.toString(), ''],
+      ['Tháng trước', statistics.trialLicenses.lastMonth.toString(), ''],
+      [
+        'Thay đổi %',
+        `${statistics.trialLicenses.changePercentage.toFixed(1)}%`,
+        'so với tháng trước',
+      ],
+      ['', '', ''], // Empty row
+
+      // Expired licenses
+      ['BẢN QUYỀN HẾT HẠN', '', ''],
+      ['Số lượng', statistics.expiredLicenses.count.toString(), ''],
+      ['Tháng này', statistics.expiredLicenses.thisMonth.toString(), ''],
+      ['Tháng trước', statistics.expiredLicenses.lastMonth.toString(), ''],
+      [
+        'Thay đổi %',
+        `${statistics.expiredLicenses.changePercentage.toFixed(1)}%`,
+        'so với tháng trước',
+      ],
+      ['', '', ''], // Empty row
+
+      // Refunded amount
+      ['ĐÃ HOÀN TIỀN', '', ''],
+      ['Tháng này:', '', ''],
+      ['  Số lượng', statistics.refundedAmount.thisMonth.toString(), ''],
+      [
+        '  Số tiền (VND)',
+        statistics.refundedAmount.thisMonthAmount.toLocaleString('vi-VN'),
+        '',
+      ],
+      ['Tháng trước:', '', ''],
+      ['  Số lượng', statistics.refundedAmount.lastMonth.toString(), ''],
+      [
+        '  Số tiền (VND)',
+        statistics.refundedAmount.lastMonthAmount.toLocaleString('vi-VN'),
+        '',
+      ],
+      ['Thay đổi so với tháng trước:', '', ''],
+      [
+        '  Số lượng',
+        `${statistics.refundedAmount.thisMonth - statistics.refundedAmount.lastMonth >= 0 ? '+' : ''}${statistics.refundedAmount.thisMonth - statistics.refundedAmount.lastMonth}`,
+        '',
+      ],
+      [
+        '  Số tiền chênh lệch (VND)',
+        `${statistics.refundedAmount.thisMonthAmount - statistics.refundedAmount.lastMonthAmount >= 0 ? '+' : ''}${(statistics.refundedAmount.thisMonthAmount - statistics.refundedAmount.lastMonthAmount).toLocaleString('vi-VN')}`,
+        '',
+      ],
+      [
+        '  % chênh lệch',
+        `${statistics.refundedAmount.changePercentage >= 0 ? '+' : ''}${statistics.refundedAmount.changePercentage.toFixed(1)}%`,
+        '',
+      ],
+      ['', '', ''], // Empty row
+
+      // Current situation
+      ['TÌNH HÌNH HIỆN TẠI', '', ''],
+      [
+        'Sắp hết hạn (30 ngày)',
+        statistics.currentSituation.expiringSoon.toString(),
+        '',
+      ],
+      [
+        'Hoạt động hôm nay',
+        statistics.currentSituation.activeToday.toString(),
+        '',
+      ],
+      [
+        'Hoạt động tuần này',
+        statistics.currentSituation.activeThisWeek.toString(),
+        '',
+      ],
+      [
+        'Hoạt động tháng này',
+        statistics.currentSituation.activeThisMonth.toString(),
+        '',
+      ],
+    ];
+
+    // Convert to CSV format
+    return csvRows
+      .map((row) =>
+        row.map((cell) => `"${cell.replace(/"/g, '""')}"`).join(','),
+      )
+      .join('\n');
+  }
+
+  generateDashboardReport(statistics: LicenseDashboardStatistics): string {
+    return `=== LICENSE DASHBOARD STATISTICS ===
+
+📊 Generated: ${statistics.generatedAt}
+
+📊 1. TỔNG BẢN QUYỀN
+   Số lượng: ${statistics.totalLicenses.count}
+   Tháng này: ${statistics.totalLicenses.thisMonth}
+   Tháng trước: ${statistics.totalLicenses.lastMonth}
+   Thay đổi: ${statistics.totalLicenses.changePercentage >= 0 ? '+' : ''}${statistics.totalLicenses.changePercentage.toFixed(1)}% so với tháng trước
+
+🟢 2. ĐANG HOẠT ĐỘNG
+   Số lượng: ${statistics.activeLicenses.count}
+   Hoạt động hôm nay: ${statistics.activeLicenses.activeToday}
+   Hoạt động hôm qua: ${statistics.activeLicenses.activeYesterday}
+   Thay đổi hàng ngày: ${statistics.activeLicenses.dailyChange >= 0 ? '+' : ''}${statistics.activeLicenses.dailyChange} so với hôm qua
+   Tỷ lệ: ${statistics.activeLicenses.percentage.toFixed(2)}% tổng số license
+
+🔄 3. SỐ BẢN QUYỀN DÙNG THỬ
+   Số lượng: ${statistics.trialLicenses.count}
+   Tháng này: ${statistics.trialLicenses.thisMonth}
+   Tháng trước: ${statistics.trialLicenses.lastMonth}
+   Thay đổi: ${statistics.trialLicenses.changePercentage >= 0 ? '+' : ''}${statistics.trialLicenses.changePercentage.toFixed(1)}% so với tháng trước
+
+❌ 4. BẢN QUYỀN HẾT HẠN
+   Số lượng: ${statistics.expiredLicenses.count}
+   Tháng này: ${statistics.expiredLicenses.thisMonth}
+   Tháng trước: ${statistics.expiredLicenses.lastMonth}
+   Thay đổi: ${statistics.expiredLicenses.changePercentage >= 0 ? '+' : ''}${statistics.expiredLicenses.changePercentage.toFixed(1)}% so với tháng trước
+
+💰 5. ĐÃ HOÀN TIỀN
+	Tháng này: 
+		Số lượng: ${statistics.refundedAmount.thisMonth}
+		Số tiền (VND): ${statistics.refundedAmount.thisMonthAmount.toLocaleString('vi-VN')}
+	Tháng Trước:
+		Số lượng: ${statistics.refundedAmount.lastMonth}
+		Số tiền (VND): ${statistics.refundedAmount.lastMonthAmount.toLocaleString('vi-VN')}
+	Thay đổi so với tháng trước:
+		Số lượng: ${statistics.refundedAmount.thisMonth - statistics.refundedAmount.lastMonth >= 0 ? '+' : ''}${statistics.refundedAmount.thisMonth - statistics.refundedAmount.lastMonth}
+		Số tiền chênh lệch (VND): ${statistics.refundedAmount.thisMonthAmount - statistics.refundedAmount.lastMonthAmount >= 0 ? '+' : ''}${(statistics.refundedAmount.thisMonthAmount - statistics.refundedAmount.lastMonthAmount).toLocaleString('vi-VN')}
+		% chênh lệch: ${statistics.refundedAmount.changePercentage >= 0 ? '+' : ''}${statistics.refundedAmount.changePercentage.toFixed(1)}%
+
+📊 6. TÌNH HÌNH HIỆN TẠI
+   📍 License sắp hết hạn:
+   - Số lượng: ${statistics.currentSituation.expiringSoon}
+   - Trong 30 ngày tới
+
+   📈 Tình hình sử dụng:
+   - Hoạt động hôm nay: ${statistics.currentSituation.activeToday}
+   - Hoạt động tuần này: ${statistics.currentSituation.activeThisWeek}
+   - Hoạt động tháng này: ${statistics.currentSituation.activeThisMonth}`;
+  }
+}

--- a/packages/twenty-server/src/mkt-core/license/license.constants.ts
+++ b/packages/twenty-server/src/mkt-core/license/license.constants.ts
@@ -8,6 +8,7 @@ export enum MKT_LICENSE_STATUS {
   RENEWING = 'RENEWING', // Đang gia hạn
   CHANGE_VARIANT = 'CHANGE_VARIANT', // Thay đổi sản phẩm license
   REFUND = 'REFUND', // Hoàn tiền
+  TRIAL = 'TRIAL', // Dùng thử
 }
 
 export const MKT_LICENSE_STATUS_OPTIONS: FieldMetadataComplexOption[] = [
@@ -40,6 +41,24 @@ export const MKT_LICENSE_STATUS_OPTIONS: FieldMetadataComplexOption[] = [
     label: 'Renewing',
     position: 4,
     color: 'yellow',
+  },
+  {
+    value: MKT_LICENSE_STATUS.CHANGE_VARIANT,
+    label: 'Change Variant',
+    position: 5,
+    color: 'purple',
+  },
+  {
+    value: MKT_LICENSE_STATUS.REFUND,
+    label: 'Refund',
+    position: 6,
+    color: 'orange',
+  },
+  {
+    value: MKT_LICENSE_STATUS.TRIAL,
+    label: 'Trial',
+    position: 7,
+    color: 'blue',
   },
 ];
 

--- a/packages/twenty-server/src/mkt-core/license/mkt-license.module.ts
+++ b/packages/twenty-server/src/mkt-core/license/mkt-license.module.ts
@@ -1,29 +1,68 @@
 import { HttpModule } from '@nestjs/axios';
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
 
+import { TokenModule } from 'src/engine/core-modules/auth/token/token.module';
+import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';
+import { ObjectMetadataModule } from 'src/engine/metadata-modules/object-metadata/object-metadata.module';
+import { TwentyORMModule } from 'src/engine/twenty-orm/twenty-orm.module';
+import { WorkspaceCacheStorageModule } from 'src/engine/workspace-cache-storage/workspace-cache-storage.module';
+import { WorkspaceDataSourceModule } from 'src/engine/workspace-datasource/workspace-datasource.module';
 import { MktCommonModule } from 'src/mkt-core/common/service/mkt-common.module';
+import { MktLicenseDashboardStatsCommand } from 'src/mkt-core/license/commands/mkt-license-dashboard-stats.command';
+import { MktLicenseDashboardStatsCronCommand } from 'src/mkt-core/license/crons/commands/mkt-license-dashboard-stats.cron.command';
+import { MktLicenseDashboardStatsCronJob } from 'src/mkt-core/license/crons/jobs/mkt-license-dashboard-stats.cron.job';
 import { MktLicenseUpdateOnePostQueryHook } from 'src/mkt-core/license/hooks/mkt-license-update-one.post-query.hook';
 import { MktLicenseUpdateOnePreQueryHook } from 'src/mkt-core/license/hooks/mkt-license-update-one.pre-query.hook';
 import { MktLicenseApiService } from 'src/mkt-core/license/integration/mkt-license-api.service';
+import { MktLicenseCsvExportController } from 'src/mkt-core/license/integration/mkt-license-csv-export.controller';
+import { MktLicenseCsvExportService } from 'src/mkt-core/license/integration/mkt-license-csv-export.service';
 import { LicenseGenerationJob } from 'src/mkt-core/license/jobs/license-generation.job';
 import { MktLicenseCreateOnePreQueryHook } from 'src/mkt-core/license/mkt-license-create-one.pre-query.hook';
 import { MktLicenseHistoryService } from 'src/mkt-core/license/mkt-license-history.service';
 import { MktLicenseService } from 'src/mkt-core/license/mkt-license.service';
+import { MktLicenseExportResolver } from 'src/mkt-core/license/resolvers/mkt-license-export.resolver';
+import { MktLicenseDashboardService } from 'src/mkt-core/license/services/mkt-license.dashboard.service';
 import { MktLicenseEventService } from 'src/mkt-core/license/services/mkt-license.event.service';
 import { MktLicenseRenewService } from 'src/mkt-core/license/services/mkt-license.renew.service';
+
 @Module({
-  imports: [HttpModule, MktCommonModule],
+  imports: [
+    HttpModule,
+    MktCommonModule,
+    TokenModule,
+    ObjectMetadataModule,
+    TwentyORMModule,
+    WorkspaceCacheStorageModule,
+    WorkspaceDataSourceModule,
+    TypeOrmModule.forFeature([Workspace], 'core'),
+  ],
+  controllers: [MktLicenseCsvExportController],
   providers: [
     MktLicenseService,
     MktLicenseCreateOnePreQueryHook,
     MktLicenseApiService,
+    MktLicenseCsvExportService,
+    MktLicenseExportResolver,
     LicenseGenerationJob,
     MktLicenseUpdateOnePreQueryHook,
     MktLicenseEventService,
     MktLicenseHistoryService,
     MktLicenseUpdateOnePostQueryHook,
     MktLicenseRenewService,
+    MktLicenseDashboardService,
+    MktLicenseDashboardStatsCommand,
+    MktLicenseDashboardStatsCronCommand,
+    MktLicenseDashboardStatsCronJob,
   ],
-  exports: [MktLicenseService, MktLicenseEventService],
+  exports: [
+    MktLicenseService,
+    MktLicenseEventService,
+    MktLicenseDashboardService,
+    MktLicenseCsvExportService,
+    MktLicenseDashboardStatsCommand,
+    MktLicenseDashboardStatsCronCommand,
+    MktLicenseDashboardStatsCronJob,
+  ],
 })
 export class MktLicenseModule {}

--- a/packages/twenty-server/src/mkt-core/license/resolvers/mkt-license-export.resolver.ts
+++ b/packages/twenty-server/src/mkt-core/license/resolvers/mkt-license-export.resolver.ts
@@ -1,0 +1,71 @@
+import { UseGuards } from '@nestjs/common';
+import { Args, Query, Resolver } from '@nestjs/graphql';
+
+import { UserAuthGuard } from 'src/engine/guards/user-auth.guard';
+import { MktLicenseCsvExportService } from 'src/mkt-core/license/integration/mkt-license-csv-export.service';
+
+@Resolver()
+export class MktLicenseExportResolver {
+  constructor(private readonly csvExportService: MktLicenseCsvExportService) {}
+
+  @UseGuards(UserAuthGuard)
+  @Query(() => String)
+  async getLicenseDashboardReport(
+    @Args('reportType', {
+      type: () => String,
+      defaultValue: 'license-dashboard',
+    })
+    reportType: string,
+  ): Promise<string> {
+    const exportData =
+      await this.csvExportService.exportLicenseDashboardCsv(reportType);
+
+    if (!exportData) {
+      throw new Error('No report data found for the specified report type');
+    }
+
+    return this.csvExportService.generateDashboardReport(exportData.metadata);
+  }
+
+  @UseGuards(UserAuthGuard)
+  @Query(() => String, {
+    description: 'Get license dashboard statistics as JSON string',
+  })
+  async getLicenseDashboardStatistics(
+    @Args('reportType', {
+      type: () => String,
+      defaultValue: 'license-dashboard',
+    })
+    reportType: string,
+  ): Promise<string> {
+    const exportData =
+      await this.csvExportService.exportLicenseDashboardCsv(reportType);
+
+    if (!exportData) {
+      throw new Error('No report data found for the specified report type');
+    }
+
+    return JSON.stringify(exportData.metadata, null, 2);
+  }
+
+  @UseGuards(UserAuthGuard)
+  @Query(() => String, {
+    description: 'Get CSV export data for license dashboard',
+  })
+  async getLicenseDashboardCsv(
+    @Args('reportType', {
+      type: () => String,
+      defaultValue: 'license-dashboard',
+    })
+    reportType: string,
+  ): Promise<string> {
+    const exportData =
+      await this.csvExportService.exportLicenseDashboardCsv(reportType);
+
+    if (!exportData) {
+      throw new Error('No report data found for the specified report type');
+    }
+
+    return exportData.data;
+  }
+}

--- a/packages/twenty-server/src/mkt-core/license/services/mkt-license.dashboard.service.ts
+++ b/packages/twenty-server/src/mkt-core/license/services/mkt-license.dashboard.service.ts
@@ -1,0 +1,498 @@
+import { Injectable, Logger } from '@nestjs/common';
+
+import { Between, MoreThanOrEqual } from 'typeorm';
+
+import { ScopedWorkspaceContextFactory } from 'src/engine/twenty-orm/factories/scoped-workspace-context.factory';
+import { TwentyORMGlobalManager } from 'src/engine/twenty-orm/twenty-orm-global.manager';
+import { MktRepositoryService } from 'src/mkt-core/common/service/mkt-repository.service';
+import { MKT_LICENSE_STATUS } from 'src/mkt-core/license/license.constants';
+import { MktLicenseWorkspaceEntity } from 'src/mkt-core/license/mkt-license.workspace-entity';
+import { ORDER_STATUS } from 'src/mkt-core/order/constants/order-status.constants';
+import { MktOrderWorkspaceEntity } from 'src/mkt-core/order/objects/mkt-order.workspace-entity';
+import { MktPaymentWorkspaceEntity } from 'src/mkt-core/payment/mkt-payment.workspace-entity';
+import {
+  DashboardDataTransformer,
+  DateRangeUtils,
+  StatisticsUtils,
+} from 'src/mkt-core/utils';
+
+export interface LicenseDashboardStats {
+  totalLicenses: {
+    count: number;
+    percentageChange: number; // % thay đổi so với tháng trước
+  };
+  activeLicenses: {
+    count: number;
+    dailyChange: number; // thay đổi so với hôm qua
+  };
+  trialLicenses: {
+    count: number;
+    percentageChange: number; // % thay đổi so với tháng trước
+  };
+  expiredLicenses: {
+    count: number;
+    percentageChange: number; // % thay đổi so với tháng trước
+  };
+  refundedAmount: {
+    amount: number;
+    percentageChange: number; // % thay đổi so với tháng trước
+  };
+  expiringLicenses: {
+    count: number;
+    daysToExpire: number; // số ngày còn lại trước khi hết hạn
+  };
+  usageStatistics: {
+    activeToday: number; // hoạt động hôm nay
+    activeThisWeek: number; // hoạt động tuần này
+    activeThisMonth: number; // hoạt động tháng này
+  };
+}
+
+@Injectable()
+export class MktLicenseDashboardService {
+  private readonly logger = new Logger(MktLicenseDashboardService.name);
+
+  constructor(
+    private readonly twentyORMGlobalManager: TwentyORMGlobalManager,
+    private readonly scopedWorkspaceContextFactory: ScopedWorkspaceContextFactory,
+    private readonly mktRepo: MktRepositoryService,
+  ) {}
+
+  async getDashboardStats(): Promise<LicenseDashboardStats | null> {
+    const workspaceId = this.scopedWorkspaceContextFactory.create().workspaceId;
+
+    if (!workspaceId) {
+      this.logger.error('Workspace ID not found when getting dashboard stats');
+
+      return null;
+    }
+
+    try {
+      const [
+        totalLicenses,
+        activeLicenses,
+        trialLicenses,
+        expiredLicenses,
+        refundedAmount,
+        expiringLicenses,
+        usageStatistics,
+      ] = await Promise.all([
+        this.getTotalLicensesStats(workspaceId),
+        this.getActiveLicensesStats(workspaceId),
+        this.getTrialLicensesStats(workspaceId),
+        this.getExpiredLicensesStats(workspaceId),
+        this.getRefundedAmountStats(workspaceId),
+        this.getExpiringLicensesStats(workspaceId),
+        this.getUsageStatistics(workspaceId),
+      ]);
+
+      return {
+        totalLicenses,
+        activeLicenses,
+        trialLicenses,
+        expiredLicenses,
+        refundedAmount,
+        expiringLicenses,
+        usageStatistics,
+      };
+    } catch (error) {
+      this.logger.error('Error getting dashboard stats', error);
+
+      return null;
+    }
+  }
+
+  private async getTotalLicensesStats(workspaceId: string) {
+    const licenseRepository =
+      await this.twentyORMGlobalManager.getRepositoryForWorkspace<MktLicenseWorkspaceEntity>(
+        workspaceId,
+        'mktLicense',
+        { shouldBypassPermissionChecks: true },
+      );
+
+    const currentMonth = DateRangeUtils.getCurrentMonth();
+    const lastMonth = DateRangeUtils.getLastMonth();
+
+    // Get current month count
+    const currentCount = await licenseRepository.count({
+      where: {
+        createdAt: MoreThanOrEqual(
+          DateRangeUtils.toISOString(currentMonth.start),
+        ),
+      },
+    });
+
+    // Get last month count
+    const lastMonthCount = await licenseRepository.count({
+      where: {
+        createdAt: Between(
+          DateRangeUtils.toISOString(lastMonth.start),
+          DateRangeUtils.toISOString(lastMonth.end),
+        ),
+      },
+    });
+
+    return DashboardDataTransformer.transformCountWithComparison(
+      currentCount,
+      lastMonthCount,
+    );
+  }
+
+  private async getActiveLicensesStats(workspaceId: string) {
+    const licenseRepository =
+      await this.twentyORMGlobalManager.getRepositoryForWorkspace<MktLicenseWorkspaceEntity>(
+        workspaceId,
+        'mktLicense',
+        { shouldBypassPermissionChecks: true },
+      );
+
+    const today = DateRangeUtils.getToday();
+    const yesterday = DateRangeUtils.getYesterday();
+
+    // Count licenses with login today
+    const todayCount = await licenseRepository.count({
+      where: {
+        status: MKT_LICENSE_STATUS.ACTIVE,
+        lastLoginAt: MoreThanOrEqual(today.start),
+      },
+    });
+
+    // Count licenses with login yesterday
+    const yesterdayCount = await licenseRepository.count({
+      where: {
+        status: MKT_LICENSE_STATUS.ACTIVE,
+        lastLoginAt: Between(yesterday.start, yesterday.end),
+      },
+    });
+
+    return DashboardDataTransformer.transformCountWithDailyChange(
+      todayCount,
+      yesterdayCount,
+    );
+  }
+
+  private async getTrialLicensesStats(workspaceId: string) {
+    const licenseRepository =
+      await this.twentyORMGlobalManager.getRepositoryForWorkspace<MktLicenseWorkspaceEntity>(
+        workspaceId,
+        'mktLicense',
+        { shouldBypassPermissionChecks: true },
+      );
+
+    const currentMonth = DateRangeUtils.getCurrentMonth();
+    const lastMonth = DateRangeUtils.getLastMonth();
+
+    // Assuming trial licenses are identified by a specific field or pattern
+    // This might need adjustment based on actual data structure
+    const currentCount = await licenseRepository.count({
+      where: {
+        // Add trial license identification logic here
+        // For example: isTrial: true, or variant.type: 'TRIAL'
+        createdAt: MoreThanOrEqual(
+          DateRangeUtils.toISOString(currentMonth.start),
+        ),
+      },
+      relations: ['mktVariant'],
+    });
+
+    const lastMonthCount = await licenseRepository.count({
+      where: {
+        createdAt: Between(
+          DateRangeUtils.toISOString(lastMonth.start),
+          DateRangeUtils.toISOString(lastMonth.end),
+        ),
+      },
+      relations: ['mktVariant'],
+    });
+
+    return DashboardDataTransformer.transformCountWithComparison(
+      currentCount,
+      lastMonthCount,
+    );
+  }
+
+  private async getExpiredLicensesStats(workspaceId: string) {
+    const licenseRepository =
+      await this.twentyORMGlobalManager.getRepositoryForWorkspace<MktLicenseWorkspaceEntity>(
+        workspaceId,
+        'mktLicense',
+        { shouldBypassPermissionChecks: true },
+      );
+
+    const currentMonth = DateRangeUtils.getCurrentMonth();
+    const lastMonth = DateRangeUtils.getLastMonth();
+
+    const currentCount = await licenseRepository.count({
+      where: {
+        status: MKT_LICENSE_STATUS.EXPIRED,
+        updatedAt: MoreThanOrEqual(
+          DateRangeUtils.toISOString(currentMonth.start),
+        ),
+      },
+    });
+
+    const lastMonthCount = await licenseRepository.count({
+      where: {
+        status: MKT_LICENSE_STATUS.EXPIRED,
+        updatedAt: Between(
+          DateRangeUtils.toISOString(lastMonth.start),
+          DateRangeUtils.toISOString(lastMonth.end),
+        ),
+      },
+    });
+
+    return DashboardDataTransformer.transformCountWithComparison(
+      currentCount,
+      lastMonthCount,
+    );
+  }
+
+  private async getRefundedAmountStats(workspaceId: string) {
+    const licenseRepository =
+      await this.twentyORMGlobalManager.getRepositoryForWorkspace<MktLicenseWorkspaceEntity>(
+        workspaceId,
+        'mktLicense',
+        { shouldBypassPermissionChecks: true },
+      );
+
+    const paymentRepository =
+      await this.twentyORMGlobalManager.getRepositoryForWorkspace<MktPaymentWorkspaceEntity>(
+        workspaceId,
+        'mktPayment',
+        { shouldBypassPermissionChecks: true },
+      );
+
+    const currentMonth = DateRangeUtils.getCurrentMonth();
+    const lastMonth = DateRangeUtils.getLastMonth();
+
+    // Get refunded licenses this month
+    const refundedLicensesThisMonth = await licenseRepository.find({
+      where: {
+        status: MKT_LICENSE_STATUS.REFUND,
+        updatedAt: MoreThanOrEqual(
+          DateRangeUtils.toISOString(currentMonth.start),
+        ),
+      },
+      relations: ['mktOrder'],
+    });
+
+    // Get refunded licenses last month
+    const refundedLicensesLastMonth = await licenseRepository.find({
+      where: {
+        status: MKT_LICENSE_STATUS.REFUND,
+        updatedAt: Between(
+          DateRangeUtils.toISOString(lastMonth.start),
+          DateRangeUtils.toISOString(lastMonth.end),
+        ),
+      },
+      relations: ['mktOrder'],
+    });
+
+    // Calculate refund amounts by getting payment information
+    const currentAmount = await this.calculateRefundAmount(
+      refundedLicensesThisMonth,
+      paymentRepository,
+    );
+
+    const lastMonthAmount = await this.calculateRefundAmount(
+      refundedLicensesLastMonth,
+      paymentRepository,
+    );
+
+    return DashboardDataTransformer.transformAmountWithComparison(
+      currentAmount,
+      lastMonthAmount,
+    );
+  }
+
+  private async calculateRefundAmount(
+    licenses: MktLicenseWorkspaceEntity[],
+    paymentRepository: Awaited<
+      ReturnType<
+        typeof this.twentyORMGlobalManager.getRepositoryForWorkspace<MktPaymentWorkspaceEntity>
+      >
+    >,
+  ): Promise<number> {
+    const amounts: number[] = [];
+
+    for (const license of licenses) {
+      if (license.mktOrder) {
+        const payments = await paymentRepository.find({
+          where: {
+            mktOrderId: license.mktOrder.id,
+            status: 'REFUNDED', // Assuming payment has status field
+          },
+        });
+
+        const orderRefundAmount =
+          DashboardDataTransformer.calculateRevenueSummary(payments);
+
+        if (orderRefundAmount > 0) {
+          amounts.push(orderRefundAmount);
+        }
+      }
+    }
+
+    return StatisticsUtils.calculateSum(amounts);
+  }
+
+  private async getExpiringLicensesStats(workspaceId: string) {
+    const licenseRepository =
+      await this.twentyORMGlobalManager.getRepositoryForWorkspace<MktLicenseWorkspaceEntity>(
+        workspaceId,
+        'mktLicense',
+        { shouldBypassPermissionChecks: true },
+      );
+
+    const futurePeriod = DateRangeUtils.getFuturePeriod(30);
+
+    const expiringLicenses = await licenseRepository.count({
+      where: {
+        status: MKT_LICENSE_STATUS.ACTIVE,
+        expiresAt: Between(futurePeriod.start, futurePeriod.end),
+      },
+    });
+
+    return DashboardDataTransformer.transformExpiringData(expiringLicenses, 30);
+  }
+
+  private async getUsageStatistics(workspaceId: string) {
+    const licenseRepository =
+      await this.twentyORMGlobalManager.getRepositoryForWorkspace<MktLicenseWorkspaceEntity>(
+        workspaceId,
+        'mktLicense',
+        { shouldBypassPermissionChecks: true },
+      );
+
+    const today = DateRangeUtils.getToday();
+    const lastWeek = DateRangeUtils.getLastNDays(7);
+    const lastMonth = DateRangeUtils.getLastNDays(30);
+
+    const [activeToday, activeThisWeek, activeThisMonth] = await Promise.all([
+      licenseRepository.count({
+        where: {
+          status: MKT_LICENSE_STATUS.ACTIVE,
+          lastLoginAt: MoreThanOrEqual(today.start),
+        },
+      }),
+      licenseRepository.count({
+        where: {
+          status: MKT_LICENSE_STATUS.ACTIVE,
+          lastLoginAt: MoreThanOrEqual(lastWeek.start),
+        },
+      }),
+      licenseRepository.count({
+        where: {
+          status: MKT_LICENSE_STATUS.ACTIVE,
+          lastLoginAt: MoreThanOrEqual(lastMonth.start),
+        },
+      }),
+    ]);
+
+    return DashboardDataTransformer.transformUsageStats(
+      activeToday,
+      activeThisWeek,
+      activeThisMonth,
+    );
+  }
+
+  // Additional helper methods for detailed analysis
+
+  async getLicensesByStatus(
+    status: MKT_LICENSE_STATUS,
+  ): Promise<MktLicenseWorkspaceEntity[]> {
+    const workspaceId = this.scopedWorkspaceContextFactory.create().workspaceId;
+
+    if (!workspaceId) {
+      this.logger.error(
+        'Workspace ID not found when getting licenses by status',
+      );
+
+      return [];
+    }
+
+    const licenseRepository =
+      await this.twentyORMGlobalManager.getRepositoryForWorkspace<MktLicenseWorkspaceEntity>(
+        workspaceId,
+        'mktLicense',
+        { shouldBypassPermissionChecks: true },
+      );
+
+    return await licenseRepository.find({
+      where: { status },
+      relations: ['mktVariant', 'mktOrder', 'mktCustomer'],
+      order: { updatedAt: 'DESC' },
+    });
+  }
+
+  async getExpiringLicensesDetailed(
+    daysAhead = 30,
+  ): Promise<MktLicenseWorkspaceEntity[]> {
+    const workspaceId = this.scopedWorkspaceContextFactory.create().workspaceId;
+
+    if (!workspaceId) {
+      this.logger.error(
+        'Workspace ID not found when getting expiring licenses',
+      );
+
+      return [];
+    }
+
+    const licenseRepository =
+      await this.twentyORMGlobalManager.getRepositoryForWorkspace<MktLicenseWorkspaceEntity>(
+        workspaceId,
+        'mktLicense',
+        { shouldBypassPermissionChecks: true },
+      );
+
+    const now = new Date();
+    const futureDate = new Date(
+      now.getTime() + daysAhead * 24 * 60 * 60 * 1000,
+    );
+
+    return await licenseRepository.find({
+      where: {
+        status: MKT_LICENSE_STATUS.ACTIVE,
+        expiresAt: Between(now, futureDate),
+      },
+      relations: ['mktVariant', 'mktOrder', 'mktCustomer'],
+      order: { expiresAt: 'ASC' },
+    });
+  }
+
+  async getRevenueByPeriod(startDate: Date, endDate: Date): Promise<number> {
+    const workspaceId = this.scopedWorkspaceContextFactory.create().workspaceId;
+
+    if (!workspaceId) {
+      this.logger.error(
+        'Workspace ID not found when getting revenue by period',
+      );
+
+      return 0;
+    }
+
+    const orderRepository =
+      await this.twentyORMGlobalManager.getRepositoryForWorkspace<MktOrderWorkspaceEntity>(
+        workspaceId,
+        'mktOrder',
+        { shouldBypassPermissionChecks: true },
+      );
+
+    const orders = await orderRepository.find({
+      where: {
+        createdAt: Between(
+          DateRangeUtils.toISOString(startDate),
+          DateRangeUtils.toISOString(endDate),
+        ),
+        status: ORDER_STATUS.COMPLETED, // Assuming completed orders
+      },
+      relations: ['mktPayments'],
+    });
+
+    const revenues = orders.map((order) =>
+      DashboardDataTransformer.calculateRevenueSummary(order.mktPayments || []),
+    );
+
+    return StatisticsUtils.calculateSum(revenues);
+  }
+}

--- a/packages/twenty-server/src/mkt-core/mkt-entities-extends/timeline-activity.mkt-entity.ts
+++ b/packages/twenty-server/src/mkt-core/mkt-entities-extends/timeline-activity.mkt-entity.ts
@@ -34,6 +34,7 @@ import { MktProductWorkspaceEntity } from 'src/mkt-core/product/objects/mkt-prod
 import { MktValueWorkspaceEntity } from 'src/mkt-core/product/objects/mkt-value.workspace-entity';
 import { MktVariantValueWorkspaceEntity } from 'src/mkt-core/product/objects/mkt-variant-value.workspace-entity';
 import { MktVariantWorkspaceEntity } from 'src/mkt-core/product/objects/mkt-variant.workspace-entity';
+import { MktReportWorkspaceEntity } from 'src/mkt-core/report/objects/mkt-report.workspace-entity';
 
 export class TimelineActivityMktEntity extends BaseWorkspaceEntity {
   @WorkspaceRelation({
@@ -417,4 +418,20 @@ export class TimelineActivityMktEntity extends BaseWorkspaceEntity {
 
   @WorkspaceJoinColumn('mktComboVariant')
   mktComboVariantId: string | null;
+
+  @WorkspaceRelation({
+    standardId: TIMELINE_ACTIVITY_MKT_FIELD_IDS.mktReport,
+    type: RelationType.MANY_TO_ONE,
+    label: msg`Report`,
+    description: msg`Event report`,
+    icon: 'IconReportAnalytics',
+    inverseSideTarget: () => MktReportWorkspaceEntity,
+    inverseSideFieldKey: 'timelineActivities',
+    onDelete: RelationOnDeleteAction.CASCADE,
+  })
+  @WorkspaceIsNullable()
+  mktReport: Relation<MktReportWorkspaceEntity> | null;
+
+  @WorkspaceJoinColumn('mktReport')
+  mktReportId: string | null;
 }

--- a/packages/twenty-server/src/mkt-core/mkt-entities-extends/workspace-member.mkt-entity.ts
+++ b/packages/twenty-server/src/mkt-core/mkt-entities-extends/workspace-member.mkt-entity.ts
@@ -45,6 +45,7 @@ import { MktProductWorkspaceEntity } from 'src/mkt-core/product/objects/mkt-prod
 import { MktValueWorkspaceEntity } from 'src/mkt-core/product/objects/mkt-value.workspace-entity';
 import { MktVariantValueWorkspaceEntity } from 'src/mkt-core/product/objects/mkt-variant-value.workspace-entity';
 import { MktVariantWorkspaceEntity } from 'src/mkt-core/product/objects/mkt-variant.workspace-entity';
+import { MktReportWorkspaceEntity } from 'src/mkt-core/report/objects/mkt-report.workspace-entity';
 
 export class WorkspaceMemberMktEntity extends BaseWorkspaceEntity {
   @WorkspaceRelation({
@@ -346,6 +347,18 @@ export class WorkspaceMemberMktEntity extends BaseWorkspaceEntity {
     onDelete: RelationOnDeleteAction.SET_NULL,
   })
   accountOwnerForMktSInvoiceFiles: Relation<MktSInvoiceFileWorkspaceEntity[]>;
+
+  @WorkspaceRelation({
+    standardId: WORKSPACE_MEMBER_MKT_FIELD_IDS.accountOwnerForMktReports,
+    type: RelationType.ONE_TO_MANY,
+    label: msg`Account Owner For Reports`,
+    description: msg`Account owner for reports`,
+    icon: 'IconFile',
+    inverseSideTarget: () => MktReportWorkspaceEntity,
+    inverseSideFieldKey: 'accountOwner',
+    onDelete: RelationOnDeleteAction.SET_NULL,
+  })
+  accountOwnerForMktReports: Relation<MktReportWorkspaceEntity[]>;
 
   @WorkspaceRelation({
     standardId: WORKSPACE_MEMBER_MKT_FIELD_IDS.accountOwnerForMktTemplates,

--- a/packages/twenty-server/src/mkt-core/order/graphql/order-status.enum.ts
+++ b/packages/twenty-server/src/mkt-core/order/graphql/order-status.enum.ts
@@ -9,6 +9,7 @@ export enum OrderStatusGraphQL {
   WAIT = OrderStatus.WAIT,
   OVERDUE = OrderStatus.OVERDUE,
   REFUSE = OrderStatus.REFUSE,
+  REFUND = OrderStatus.REFUND,
 }
 
 registerEnumType(OrderStatusGraphQL, {
@@ -32,6 +33,9 @@ registerEnumType(OrderStatusGraphQL, {
     },
     REFUSE: {
       description: 'Order is refused',
+    },
+    REFUND: {
+      description: 'Order is refunded',
     },
   },
 });

--- a/packages/twenty-server/src/mkt-core/order/utils/order-status.mapper.ts
+++ b/packages/twenty-server/src/mkt-core/order/utils/order-status.mapper.ts
@@ -17,6 +17,7 @@ export function mapGraphQLOrderStatusToEntity(
     [OrderStatusGraphQL.WAIT]: OrderStatus.WAIT,
     [OrderStatusGraphQL.OVERDUE]: OrderStatus.OVERDUE,
     [OrderStatusGraphQL.REFUSE]: OrderStatus.REFUSE,
+    [OrderStatusGraphQL.REFUND]: OrderStatus.REFUND,
   };
 
   const mappedStatus = statusMap[graphqlStatus];
@@ -41,6 +42,7 @@ export function mapEntityOrderStatusToGraphQL(
     [OrderStatus.WAIT]: OrderStatusGraphQL.WAIT,
     [OrderStatus.OVERDUE]: OrderStatusGraphQL.OVERDUE,
     [OrderStatus.REFUSE]: OrderStatusGraphQL.REFUSE,
+    [OrderStatus.REFUND]: OrderStatusGraphQL.REFUND,
   };
 
   const mappedStatus = statusMap[entityStatus];

--- a/packages/twenty-server/src/mkt-core/report/objects/mkt-report.workspace-entity.ts
+++ b/packages/twenty-server/src/mkt-core/report/objects/mkt-report.workspace-entity.ts
@@ -1,0 +1,152 @@
+import { msg } from '@lingui/core/macro';
+import { FieldMetadataType } from 'twenty-shared/types';
+
+import { RelationOnDeleteAction } from 'src/engine/metadata-modules/field-metadata/interfaces/relation-on-delete-action.interface';
+import { RelationType } from 'src/engine/metadata-modules/field-metadata/interfaces/relation-type.interface';
+import { Relation } from 'src/engine/workspace-manager/workspace-sync-metadata/interfaces/relation.interface';
+
+import { SEARCH_VECTOR_FIELD } from 'src/engine/metadata-modules/constants/search-vector-field.constants';
+import { ActorMetadata } from 'src/engine/metadata-modules/field-metadata/composite-types/actor.composite-type';
+import { IndexType } from 'src/engine/metadata-modules/index-metadata/types/indexType.types';
+import { BaseWorkspaceEntity } from 'src/engine/twenty-orm/base.workspace-entity';
+import { WorkspaceEntity } from 'src/engine/twenty-orm/decorators/workspace-entity.decorator';
+import { WorkspaceFieldIndex } from 'src/engine/twenty-orm/decorators/workspace-field-index.decorator';
+import { WorkspaceField } from 'src/engine/twenty-orm/decorators/workspace-field.decorator';
+import { WorkspaceIsNullable } from 'src/engine/twenty-orm/decorators/workspace-is-nullable.decorator';
+import { WorkspaceIsSearchable } from 'src/engine/twenty-orm/decorators/workspace-is-searchable.decorator';
+import { WorkspaceIsSystem } from 'src/engine/twenty-orm/decorators/workspace-is-system.decorator';
+import { WorkspaceJoinColumn } from 'src/engine/twenty-orm/decorators/workspace-join-column.decorator';
+import { WorkspaceRelation } from 'src/engine/twenty-orm/decorators/workspace-relation.decorator';
+import {
+  FieldTypeAndNameMetadata,
+  getTsVectorColumnExpressionFromFields,
+} from 'src/engine/workspace-manager/workspace-sync-metadata/utils/get-ts-vector-column-expression.util';
+import { MKT_REPORT_FIELD_IDS } from 'src/mkt-core/constants/mkt-field-ids';
+import { MKT_OBJECT_IDS } from 'src/mkt-core/constants/mkt-object-ids';
+import { SEARCH_FIELDS_FOR_MKT_ATTRIBUTE } from 'src/mkt-core/product/objects/mkt-attribute.workspace-entity';
+import { TimelineActivityWorkspaceEntity } from 'src/modules/timeline/standard-objects/timeline-activity.workspace-entity';
+import { WorkspaceMemberWorkspaceEntity } from 'src/modules/workspace-member/standard-objects/workspace-member.workspace-entity';
+
+const TABLE_REPORT_NAME = 'mktReport';
+const NAME_FIELD_NAME = 'name';
+
+export const SEARCH_FIELDS_FOR_MKT_REPORT: FieldTypeAndNameMetadata[] = [
+  { name: NAME_FIELD_NAME, type: FieldMetadataType.TEXT },
+];
+
+@WorkspaceEntity({
+  standardId: MKT_OBJECT_IDS.mktReport,
+  namePlural: `${TABLE_REPORT_NAME}s`,
+  labelSingular: msg`Report`,
+  labelPlural: msg`Reports`,
+  description: msg`Assign reports to your workspace`,
+  icon: 'IconTag',
+  labelIdentifierStandardId: MKT_REPORT_FIELD_IDS.name,
+})
+@WorkspaceIsSearchable()
+export class MktReportWorkspaceEntity extends BaseWorkspaceEntity {
+  @WorkspaceField({
+    standardId: MKT_REPORT_FIELD_IDS.name,
+    type: FieldMetadataType.TEXT,
+    label: msg`Name`,
+    description: msg`Report name`,
+    icon: 'IconTag',
+  })
+  name: string;
+
+  @WorkspaceField({
+    standardId: MKT_REPORT_FIELD_IDS.position,
+    type: FieldMetadataType.POSITION,
+    label: msg`Position`,
+    description: msg`Position in the list`,
+    icon: 'IconHierarchy2',
+  })
+  @WorkspaceIsNullable()
+  position?: number;
+
+  @WorkspaceField({
+    standardId: MKT_REPORT_FIELD_IDS.createdBy,
+    type: FieldMetadataType.ACTOR,
+    label: msg`Created by`,
+    icon: 'IconCreativeCommonsSa',
+    description: msg`The creator of the record`,
+  })
+  @WorkspaceIsNullable()
+  createdBy: ActorMetadata;
+
+  @WorkspaceField({
+    standardId: MKT_REPORT_FIELD_IDS.notes,
+    type: FieldMetadataType.TEXT,
+    label: msg`Notes`,
+    description: msg`Report notes`,
+    icon: 'IconFileDescription',
+  })
+  @WorkspaceIsNullable()
+  notes: string;
+
+  @WorkspaceField({
+    standardId: MKT_REPORT_FIELD_IDS.metadata,
+    type: FieldMetadataType.RAW_JSON,
+    label: msg`Metadata`,
+    description: msg`Report metadata`,
+    icon: 'IconFileAnalytics',
+  })
+  @WorkspaceIsNullable()
+  metadata: JSON;
+
+  @WorkspaceField({
+    standardId: MKT_REPORT_FIELD_IDS.reportType,
+    type: FieldMetadataType.TEXT,
+    label: msg`Type`,
+    description: msg`Report type`,
+    icon: 'IconFileDescription',
+  })
+  @WorkspaceIsNullable()
+  reportType: string;
+
+  @WorkspaceRelation({
+    standardId: MKT_REPORT_FIELD_IDS.accountOwner,
+    type: RelationType.MANY_TO_ONE,
+    label: msg`Account Owner`,
+    description: msg`Your team member responsible for managing the report`,
+    icon: 'IconUserCircle',
+    inverseSideTarget: () => WorkspaceMemberWorkspaceEntity,
+    inverseSideFieldKey: 'accountOwnerForMktReports',
+    onDelete: RelationOnDeleteAction.SET_NULL,
+  })
+  @WorkspaceIsNullable()
+  accountOwner: Relation<WorkspaceMemberWorkspaceEntity> | null;
+
+  @WorkspaceJoinColumn('accountOwner')
+  accountOwnerId: string | null;
+
+  @WorkspaceRelation({
+    standardId: MKT_REPORT_FIELD_IDS.timelineActivities,
+    type: RelationType.ONE_TO_MANY,
+    label: msg`Timeline Activities`,
+    description: msg`Timeline Activities linked to the report`,
+    icon: 'IconIconTimelineEvent',
+    inverseSideTarget: () => TimelineActivityWorkspaceEntity,
+    inverseSideFieldKey: 'mktReport',
+    onDelete: RelationOnDeleteAction.CASCADE,
+  })
+  @WorkspaceIsNullable()
+  @WorkspaceIsSystem()
+  timelineActivities: Relation<TimelineActivityWorkspaceEntity[]>;
+
+  @WorkspaceField({
+    standardId: MKT_REPORT_FIELD_IDS.searchVector,
+    type: FieldMetadataType.TS_VECTOR,
+    label: SEARCH_VECTOR_FIELD.label,
+    description: SEARCH_VECTOR_FIELD.description,
+    icon: 'IconUser',
+    generatedType: 'STORED',
+    asExpression: getTsVectorColumnExpressionFromFields(
+      SEARCH_FIELDS_FOR_MKT_ATTRIBUTE,
+    ),
+  })
+  @WorkspaceIsNullable()
+  @WorkspaceIsSystem()
+  @WorkspaceFieldIndex({ indexType: IndexType.GIN })
+  searchVector: string;
+}

--- a/packages/twenty-server/src/mkt-core/report/seeder/mkt-report-all.view.ts
+++ b/packages/twenty-server/src/mkt-core/report/seeder/mkt-report-all.view.ts
@@ -1,0 +1,75 @@
+import { ObjectMetadataEntity } from 'src/engine/metadata-modules/object-metadata/object-metadata.entity';
+import { MKT_REPORT_FIELD_IDS } from 'src/mkt-core/constants/mkt-field-ids';
+import { MKT_OBJECT_IDS } from 'src/mkt-core/constants/mkt-object-ids';
+import { ViewOpenRecordInType } from 'src/modules/view/standard-objects/view.workspace-entity';
+
+export const mktReportsAllView = (
+  objectMetadataItems: ObjectMetadataEntity[],
+) => {
+  const itemObjectMetadata = objectMetadataItems.find(
+    (object) => object.standardId === MKT_OBJECT_IDS.mktReport,
+  );
+
+  if (!itemObjectMetadata) {
+    throw new Error('Report object metadata not found');
+  }
+
+  return {
+    name: 'All Reports',
+    objectMetadataId: itemObjectMetadata.id ?? '',
+    type: 'table',
+    key: 'INDEX',
+    position: 10,
+    icon: 'IconBox',
+    kanbanFieldMetadataId: '',
+    openRecordIn: ViewOpenRecordInType.SIDE_PANEL,
+    filters: [],
+    fields: [
+      {
+        fieldMetadataId:
+          itemObjectMetadata.fields.find(
+            (field) => field.standardId === MKT_REPORT_FIELD_IDS.name,
+          )?.id ?? '',
+        position: 0,
+        isVisible: true,
+        size: 180,
+      },
+      {
+        fieldMetadataId:
+          itemObjectMetadata.fields.find(
+            (field) => field.standardId === MKT_REPORT_FIELD_IDS.notes,
+          )?.id ?? '',
+        position: 1,
+        isVisible: true,
+        size: 150,
+      },
+      {
+        fieldMetadataId:
+          itemObjectMetadata.fields.find(
+            (field) => field.standardId === MKT_REPORT_FIELD_IDS.reportType,
+          )?.id ?? '',
+        position: 2,
+        isVisible: true,
+        size: 150,
+      },
+      {
+        fieldMetadataId:
+          itemObjectMetadata.fields.find(
+            (field) => field.standardId === MKT_REPORT_FIELD_IDS.createdBy,
+          )?.id ?? '',
+        position: 3,
+        isVisible: true,
+        size: 120,
+      },
+      {
+        fieldMetadataId:
+          itemObjectMetadata.fields.find(
+            (field) => field.standardId === MKT_REPORT_FIELD_IDS.metadata,
+          )?.id ?? '',
+        position: 4,
+        isVisible: true,
+        size: 120,
+      },
+    ],
+  };
+};

--- a/packages/twenty-server/src/mkt-core/report/seeder/mkt-report-data-seed-dev-workspace.command.ts
+++ b/packages/twenty-server/src/mkt-core/report/seeder/mkt-report-data-seed-dev-workspace.command.ts
@@ -1,0 +1,311 @@
+import { Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+
+import { Command, CommandRunner, Option } from 'nest-commander';
+import { WorkspaceActivationStatus } from 'twenty-shared/workspace';
+import { Repository } from 'typeorm';
+import { v4 as uuidv4 } from 'uuid';
+
+import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';
+import { ObjectMetadataService } from 'src/engine/metadata-modules/object-metadata/object-metadata.service';
+import { WorkspaceEntityManager } from 'src/engine/twenty-orm/entity-manager/workspace-entity-manager';
+import { WorkspaceCacheStorageService } from 'src/engine/workspace-cache-storage/workspace-cache-storage.service';
+import { getWorkspaceSchemaName } from 'src/engine/workspace-datasource/utils/get-workspace-schema-name.util';
+import { WorkspaceDataSourceService } from 'src/engine/workspace-datasource/workspace-datasource.service';
+import { mktReportsAllView as mktAllView } from 'src/mkt-core/report/seeder/mkt-report-all.view';
+import { prefillMktReports as prefillMktData } from 'src/mkt-core/report/seeder/prefill-mkt-reports';
+
+interface SeedModuleOptions {
+  workspaceId?: string;
+}
+
+const TABLE_NAME = 'All Reports';
+const nameSingular = 'mktReport';
+
+type viewDefinition = ReturnType<typeof mktAllView>;
+
+@Command({
+  name: 'workspace:seed:report-module',
+  description: 'Seed module views and data for existing workspace',
+})
+export class SeedMktReportModuleCommand extends CommandRunner {
+  private readonly logger = new Logger(SeedMktReportModuleCommand.name);
+
+  constructor(
+    @InjectRepository(Workspace, 'core')
+    private readonly workspaceRepository: Repository<Workspace>,
+    private readonly objectMetadataService: ObjectMetadataService,
+    private readonly workspaceDataSourceService: WorkspaceDataSourceService,
+    private readonly workspaceCacheStorageService: WorkspaceCacheStorageService,
+  ) {
+    super();
+  }
+
+  @Option({
+    flags: '-w, --workspace-id [workspace_id]',
+    description: 'workspace id to seed module for',
+  })
+  parseWorkspaceId(value: string): string {
+    return value;
+  }
+
+  async run(passedParam: string[], options: SeedModuleOptions): Promise<void> {
+    let workspaces: Workspace[] = [];
+
+    if (options.workspaceId) {
+      const workspace = await this.workspaceRepository.findOne({
+        where: { id: options.workspaceId },
+      });
+
+      if (workspace) {
+        workspaces = [workspace];
+      } else {
+        this.logger.error(`Workspace ${options.workspaceId} not found`);
+
+        return;
+      }
+    } else {
+      // Seed for all active workspaces
+      workspaces = await this.workspaceRepository.find({
+        where: {
+          activationStatus: WorkspaceActivationStatus.ACTIVE,
+        },
+      });
+    }
+
+    for (const workspace of workspaces) {
+      try {
+        await this.seedModuleForWorkspace(workspace.id);
+        const mainDataSource =
+          await this.workspaceDataSourceService.connectToMainDataSource();
+        const schemaName = getWorkspaceSchemaName(workspace.id);
+        const viewRow = await mainDataSource
+          .createQueryBuilder()
+          .select('id')
+          .from(`${schemaName}.view`, 'view')
+          .where('view.name = :name', { name: TABLE_NAME })
+          .andWhere('view.key = :key', { key: 'INDEX' })
+          .getRawOne();
+        const viewId = viewRow?.id;
+
+        if (viewId) {
+          // Insert mới Favorite với viewId này
+          await mainDataSource
+            .createQueryBuilder()
+            .insert()
+            .into(`${schemaName}.favorite`, ['viewId'])
+            .values([{ viewId: viewId }])
+            .execute();
+          this.logger.log(
+            `✅ Inserted new Favorite record with viewId: ${viewId}`,
+          );
+        } else {
+          this.logger.warn(
+            '⚠️ Could not find viewId for All view to update Favorite records',
+          );
+        }
+        this.logger.log(`✅ module seeded for workspace: ${workspace.id}`);
+        await this.workspaceCacheStorageService.flush(workspace.id, undefined);
+      } catch (error) {
+        this.logger.error(
+          `❌ Failed to seed module for workspace ${workspace.id}:`,
+          error,
+        );
+      }
+    }
+  }
+
+  private async seedModuleForWorkspace(workspaceId: string): Promise<void> {
+    this.logger.log(`🚀 Starting module seeding for workspace ${workspaceId}`);
+
+    const mainDataSource =
+      await this.workspaceDataSourceService.connectToMainDataSource();
+
+    if (!mainDataSource) {
+      throw new Error('Could not connect to main data source');
+    }
+
+    const objectMetadataItems =
+      await this.objectMetadataService.findManyWithinWorkspace(workspaceId);
+
+    const objectMetadata = objectMetadataItems.find(
+      (item) => item.nameSingular === nameSingular,
+    );
+
+    this.logger.log(
+      `🔍 Debug - All objects in workspace: ${objectMetadataItems.map((item) => `${item.nameSingular}(${item.standardId})`).join(', ')}`,
+    );
+    this.logger.log(`🔍 Debug - Looking for object with nameSingular`);
+    this.logger.log(
+      `🔍 Debug - Object found: ${objectMetadata ? 'YES' : 'NO'}`,
+    );
+
+    if (!objectMetadata) {
+      this.logger.log(
+        `object not found in workspace ${workspaceId}, skipping...`,
+      );
+
+      return;
+    }
+
+    const schemaName = getWorkspaceSchemaName(workspaceId);
+
+    this.logger.warn(`🔍 Debug - Workspace schema name: ${schemaName}`);
+    await mainDataSource.transaction(
+      async (entityManager: WorkspaceEntityManager) => {
+        const existingView = await entityManager
+          .createQueryBuilder(undefined, undefined, undefined, {
+            shouldBypassPermissionChecks: true,
+          })
+          .select('*')
+          .from(`${schemaName}.view`, 'view')
+          .where('view.name = :name', { name: TABLE_NAME })
+          .andWhere('view.key = :key', { key: 'INDEX' })
+          .getRawOne();
+
+        if (existingView) {
+          this.logger.log(
+            `View already exists for workspace ${workspaceId}. Deleting and recreating...`,
+          );
+
+          // Delete existing view (cascade will delete viewFields)
+          await entityManager
+            .createQueryBuilder(undefined, undefined, undefined, {
+              shouldBypassPermissionChecks: true,
+            })
+            .delete()
+            .from(`${schemaName}.view`)
+            .where('name = :name', { name: TABLE_NAME })
+            .andWhere('key = :key', { key: 'INDEX' })
+            .execute();
+        }
+
+        this.logger.warn(`🔍 Debug - Creating view definition`);
+        const viewDefinition: viewDefinition = mktAllView(objectMetadataItems);
+
+        await prefillMktData(entityManager, schemaName);
+
+        if (!viewDefinition) {
+          this.logger.log(
+            `Could not create view definition for workspace ${workspaceId}`,
+          );
+
+          return;
+        }
+
+        this.logger.log(
+          `🔍 Debug - View definition created with ${viewDefinition.fields?.length || 0} fields`,
+        );
+
+        const viewDefinitionWithId = {
+          ...viewDefinition,
+          id: uuidv4(),
+        };
+
+        // Insert view
+        await entityManager
+          .createQueryBuilder(undefined, undefined, undefined, {
+            shouldBypassPermissionChecks: true,
+          })
+          .insert()
+          .into(`${schemaName}.view`, [
+            'id',
+            'name',
+            'objectMetadataId',
+            'type',
+            'key',
+            'position',
+            'icon',
+            'openRecordIn',
+            'kanbanFieldMetadataId',
+          ])
+          .values({
+            id: viewDefinitionWithId.id,
+            name: viewDefinitionWithId.name,
+            objectMetadataId: viewDefinitionWithId.objectMetadataId,
+            type: viewDefinitionWithId.type,
+            key: viewDefinitionWithId.key,
+            position: viewDefinitionWithId.position,
+            icon: viewDefinitionWithId.icon,
+            openRecordIn: viewDefinitionWithId.openRecordIn,
+            kanbanFieldMetadataId: viewDefinitionWithId.kanbanFieldMetadataId,
+          })
+          .execute();
+
+        // Insert view fields
+        if (
+          viewDefinitionWithId.fields &&
+          viewDefinitionWithId.fields.length > 0
+        ) {
+          this.logger.log(
+            `🔍 Debug - Creating ${viewDefinitionWithId.fields.length} view fields`,
+          );
+          await entityManager
+            .createQueryBuilder(undefined, undefined, undefined, {
+              shouldBypassPermissionChecks: true,
+            })
+            .insert()
+            .into(`${schemaName}.viewField`, [
+              'id',
+              'fieldMetadataId',
+              'position',
+              'isVisible',
+              'size',
+              'viewId',
+            ])
+            .values(
+              viewDefinitionWithId.fields.map((field) => ({
+                id: uuidv4(),
+                fieldMetadataId: field.fieldMetadataId,
+                position: field.position,
+                isVisible: field.isVisible,
+                size: field.size,
+                viewId: viewDefinitionWithId.id,
+              })),
+            )
+            .execute();
+          this.logger.log(`✅ View fields created successfully`);
+        }
+
+        // Insert view filters if any
+        // Insert view filters if any
+        if (
+          viewDefinitionWithId.filters &&
+          viewDefinitionWithId.filters.length > 0
+        ) {
+          await entityManager
+            .createQueryBuilder(undefined, undefined, undefined, {
+              shouldBypassPermissionChecks: true,
+            })
+            .insert()
+            .into(`${schemaName}.viewFilter`, [
+              'fieldMetadataId',
+              'operand',
+              'value',
+              'displayValue',
+              'viewId',
+            ])
+            .values(
+              (
+                viewDefinitionWithId.filters as Array<{
+                  fieldMetadataId: string;
+                  operand: string;
+                  value: unknown;
+                  displayValue: string;
+                }>
+              ).map((filter) => ({
+                fieldMetadataId: filter.fieldMetadataId,
+                operand: filter.operand,
+                value: filter.value,
+                displayValue: filter.displayValue,
+                viewId: viewDefinitionWithId.id,
+              })),
+            )
+            .execute();
+        }
+
+        this.logger.log(`✅ View created for workspace ${workspaceId}`);
+      },
+    );
+  }
+}

--- a/packages/twenty-server/src/mkt-core/report/seeder/prefill-mkt-reports.ts
+++ b/packages/twenty-server/src/mkt-core/report/seeder/prefill-mkt-reports.ts
@@ -1,0 +1,19 @@
+import { WorkspaceEntityManager } from 'src/engine/twenty-orm/entity-manager/workspace-entity-manager';
+import {
+  MKT_REPORT_DATA_SEED_COLUMNS,
+  MKT_REPORT_DATA_SEEDS,
+} from 'src/mkt-core/dev-seeder/constants/mkt-report-data-seeds.constants';
+
+export const prefillMktReports = async (
+  entityManager: WorkspaceEntityManager,
+  schemaName: string,
+) => {
+  await entityManager
+    .createQueryBuilder(undefined, undefined, undefined, {
+      shouldBypassPermissionChecks: true,
+    })
+    .insert()
+    .into(`${schemaName}.mktReport`, MKT_REPORT_DATA_SEED_COLUMNS)
+    .values(MKT_REPORT_DATA_SEEDS)
+    .execute();
+};

--- a/packages/twenty-server/src/mkt-core/user-management/user-management.service.ts
+++ b/packages/twenty-server/src/mkt-core/user-management/user-management.service.ts
@@ -20,12 +20,12 @@ import { TwentyORMGlobalManager } from 'src/engine/twenty-orm/twenty-orm-global.
 import { WorkspaceDataSourceService } from 'src/engine/workspace-datasource/workspace-datasource.service';
 import { CreateUserInput } from 'src/mkt-core/user-management/dto/create-user.input';
 import { WorkspaceMemberWorkspaceEntity } from 'src/modules/workspace-member/standard-objects/workspace-member.workspace-entity';
-
 import {
   SendEmailToolException,
   SendEmailToolExceptionCode,
 } from 'src/engine/core-modules/tool/tools/send-email-tool/exceptions/send-email-tool.exception';
 import { MktSendmailTemplateWorkspaceEntity } from 'src/mkt-core/mkt-sendmail-template/mkt-sendmail-template.workpace-entity';
+
 import { UserOutput } from './dto/user.output';
 
 @Injectable()
@@ -69,6 +69,7 @@ export class UserManagementService {
     // Trộn ngẫu nhiên
     for (let i = password.length - 1; i > 0; i--) {
       const j = Math.floor(Math.random() * (i + 1));
+
       [password[i], password[j]] = [password[j], password[i]];
     }
 
@@ -155,6 +156,7 @@ export class UserManagementService {
         { shouldBypassPermissionChecks: true },
       );
     let savedWorkspaceMember: WorkspaceMemberWorkspaceEntity;
+
     try {
       savedWorkspaceMember = await workspaceMemberRepo.save({
         name: {
@@ -234,6 +236,7 @@ export class UserManagementService {
         SendEmailToolExceptionCode.CONNECTED_ACCOUNT_NOT_FOUND,
       );
     }
+
     return {
       id: savedWorkspaceMember.id,
       email,

--- a/packages/twenty-server/src/mkt-core/utils/README.md
+++ b/packages/twenty-server/src/mkt-core/utils/README.md
@@ -1,0 +1,132 @@
+# MKT Dashboard Utilities
+
+Bộ công cụ utilities được tách ra từ `mkt-license.dashboard.service.ts` để tái sử dụng và duy trì dễ dàng.
+
+## Cấu trúc
+
+```
+src/mkt-core/utils/
+├── date-range.utils.ts              # Utilities xử lý khoảng thời gian
+├── statistics.utils.ts              # Utilities tính toán thống kê
+├── dashboard-data-transformer.utils.ts # Utilities biến đổi dữ liệu dashboard
+├── array.utils.ts                   # Utilities xử lý mảng
+└── index.ts                        # Export tất cả utilities
+```
+
+## Các Utilities
+
+### 1. DateRangeUtils
+Xử lý các khoảng thời gian thường dùng trong dashboard:
+
+```typescript
+// Lấy tháng hiện tại
+const currentMonth = DateRangeUtils.getCurrentMonth();
+
+// Lấy tháng trước
+const lastMonth = DateRangeUtils.getLastMonth();
+
+// Lấy hôm nay
+const today = DateRangeUtils.getToday();
+
+// Lấy 30 ngày gần đây
+const last30Days = DateRangeUtils.getLastNDays(30);
+```
+
+### 2. StatisticsUtils
+Các phép tính thống kê cơ bản:
+
+```typescript
+// Tính phần trăm thay đổi
+const change = StatisticsUtils.calculatePercentageChange(100, 80); // 25%
+
+// Tính trung bình
+const avg = StatisticsUtils.calculateAverage([10, 20, 30]); // 20
+
+// Format số tiền
+const currency = StatisticsUtils.formatCurrency(1234.56); // "$1,234.56"
+```
+
+### 3. DashboardDataTransformer
+Biến đổi dữ liệu thô thành format dashboard:
+
+```typescript
+// Transform dữ liệu so sánh
+const stats = DashboardDataTransformer.transformCountWithComparison(100, 80);
+// { count: 100, percentageChange: 25 }
+
+// Transform dữ liệu thay đổi hàng ngày
+const dailyStats = DashboardDataTransformer.transformCountWithDailyChange(50, 45);
+// { count: 50, dailyChange: 5 }
+```
+
+### 4. ArrayUtils
+Xử lý mảng và collections:
+
+```typescript
+// Group theo key
+const grouped = ArrayUtils.groupBy(items, 'status');
+
+// Tính tổng theo điều kiện
+const total = ArrayUtils.sumBy(items, item => item.amount);
+
+// Phân trang
+const paginated = ArrayUtils.paginate(items, 1, 10);
+```
+
+## Lợi ích
+
+### 1. **Tách biệt logic**
+- Logic tính toán không phụ thuộc vào database
+- Có thể test độc lập
+- Dễ dàng tái sử dụng ở các service khác
+
+### 2. **Maintainability**
+- Code rõ ràng, dễ hiểu
+- Tách biệt responsibility
+- Dễ dàng debug và fix bug
+
+### 3. **Reusability**
+- Có thể sử dụng trong nhiều service khác
+- Không cần duplicate code
+- Consistent logic across application
+
+### 4. **Testability**
+- Pure functions, dễ test
+- Mock được dễ dàng
+- Unit test coverage cao
+
+## Cách sử dụng
+
+```typescript
+import {
+  DateRangeUtils,
+  StatisticsUtils,
+  DashboardDataTransformer,
+  ArrayUtils,
+} from 'src/mkt-core/utils';
+
+// Trong service
+export class YourService {
+  async getStats() {
+    const currentMonth = DateRangeUtils.getCurrentMonth();
+    const data = await this.repository.find({
+      where: {
+        createdAt: MoreThanOrEqual(currentMonth.start)
+      }
+    });
+    
+    return DashboardDataTransformer.transformCountWithComparison(
+      data.length, 
+      previousCount
+    );
+  }
+}
+```
+
+## Các utilities có thể mở rộng thêm
+
+1. **ValidationUtils** - Validate dữ liệu
+2. **CacheUtils** - Xử lý cache
+3. **ExportUtils** - Export dữ liệu (Excel, CSV)
+4. **NotificationUtils** - Gửi thông báo
+5. **ReportUtils** - Tạo báo cáo

--- a/packages/twenty-server/src/mkt-core/utils/array.utils.ts
+++ b/packages/twenty-server/src/mkt-core/utils/array.utils.ts
@@ -1,0 +1,212 @@
+/**
+ * Utilities for processing arrays and collections
+ */
+export class ArrayUtils {
+  /**
+   * Group array items by a key
+   */
+  static groupBy<T, K extends keyof T>(
+    array: T[],
+    key: K,
+  ): Record<string, T[]> {
+    return array.reduce(
+      (groups, item) => {
+        const groupKey = String(item[key]);
+
+        if (!groups[groupKey]) {
+          groups[groupKey] = [];
+        }
+        groups[groupKey].push(item);
+
+        return groups;
+      },
+      {} as Record<string, T[]>,
+    );
+  }
+
+  /**
+   * Group array items by a custom function
+   */
+  static groupByFunction<T>(
+    array: T[],
+    groupFunction: (item: T) => string,
+  ): Record<string, T[]> {
+    return array.reduce(
+      (groups, item) => {
+        const groupKey = groupFunction(item);
+
+        if (!groups[groupKey]) {
+          groups[groupKey] = [];
+        }
+        groups[groupKey].push(item);
+
+        return groups;
+      },
+      {} as Record<string, T[]>,
+    );
+  }
+
+  /**
+   * Extract unique values from array by key
+   */
+  static uniqueBy<T, K extends keyof T>(array: T[], key: K): T[] {
+    const seen = new Set();
+
+    return array.filter((item) => {
+      const value = item[key];
+
+      if (seen.has(value)) {
+        return false;
+      }
+      seen.add(value);
+
+      return true;
+    });
+  }
+
+  /**
+   * Sort array by multiple criteria
+   */
+  static sortBy<T>(
+    array: T[],
+    ...criteria: Array<(item: T) => string | number | Date>
+  ): T[] {
+    return [...array].sort((a, b) => {
+      for (const criterion of criteria) {
+        const valueA = criterion(a);
+        const valueB = criterion(b);
+
+        if (valueA < valueB) return -1;
+        if (valueA > valueB) return 1;
+      }
+
+      return 0;
+    });
+  }
+
+  /**
+   * Filter array by multiple conditions
+   */
+  static filterBy<T>(array: T[], conditions: Array<(item: T) => boolean>): T[] {
+    return array.filter((item) =>
+      conditions.every((condition) => condition(item)),
+    );
+  }
+
+  /**
+   * Paginate array
+   */
+  static paginate<T>(
+    array: T[],
+    page: number,
+    pageSize: number,
+  ): {
+    items: T[];
+    totalItems: number;
+    totalPages: number;
+    currentPage: number;
+    hasNextPage: boolean;
+    hasPreviousPage: boolean;
+  } {
+    const startIndex = (page - 1) * pageSize;
+    const endIndex = startIndex + pageSize;
+    const items = array.slice(startIndex, endIndex);
+    const totalItems = array.length;
+    const totalPages = Math.ceil(totalItems / pageSize);
+
+    return {
+      items,
+      totalItems,
+      totalPages,
+      currentPage: page,
+      hasNextPage: page < totalPages,
+      hasPreviousPage: page > 1,
+    };
+  }
+
+  /**
+   * Calculate sum of numeric property in array
+   */
+  static sumBy<T>(
+    array: T[],
+    keyOrFunction: keyof T | ((item: T) => number),
+  ): number {
+    return array.reduce((sum, item) => {
+      const value =
+        typeof keyOrFunction === 'function'
+          ? keyOrFunction(item)
+          : Number(item[keyOrFunction]) || 0;
+
+      return sum + value;
+    }, 0);
+  }
+
+  /**
+   * Find items that match a condition
+   */
+  static findAll<T>(array: T[], condition: (item: T) => boolean): T[] {
+    return array.filter(condition);
+  }
+
+  /**
+   * Count items that match a condition
+   */
+  static countBy<T>(array: T[], condition: (item: T) => boolean): number {
+    return array.filter(condition).length;
+  }
+
+  /**
+   * Check if array contains any item matching condition
+   */
+  static some<T>(array: T[], condition: (item: T) => boolean): boolean {
+    return array.some(condition);
+  }
+
+  /**
+   * Check if all items in array match condition
+   */
+  static every<T>(array: T[], condition: (item: T) => boolean): boolean {
+    return array.every(condition);
+  }
+
+  /**
+   * Create chunks of array
+   */
+  static chunk<T>(array: T[], size: number): T[][] {
+    const chunks: T[][] = [];
+
+    for (let i = 0; i < array.length; i += size) {
+      chunks.push(array.slice(i, i + size));
+    }
+
+    return chunks;
+  }
+
+  /**
+   * Flatten nested arrays
+   */
+  static flatten<T>(arrays: T[][]): T[] {
+    return arrays.reduce((flat, arr) => flat.concat(arr), []);
+  }
+
+  /**
+   * Remove duplicates from array
+   */
+  static unique<T>(array: T[]): T[] {
+    return [...new Set(array)];
+  }
+
+  /**
+   * Get intersection of two arrays
+   */
+  static intersection<T>(array1: T[], array2: T[]): T[] {
+    return array1.filter((item) => array2.includes(item));
+  }
+
+  /**
+   * Get difference between two arrays
+   */
+  static difference<T>(array1: T[], array2: T[]): T[] {
+    return array1.filter((item) => !array2.includes(item));
+  }
+}

--- a/packages/twenty-server/src/mkt-core/utils/dashboard-data-transformer.utils.ts
+++ b/packages/twenty-server/src/mkt-core/utils/dashboard-data-transformer.utils.ts
@@ -1,0 +1,555 @@
+import { StatisticsUtils } from './statistics.utils';
+
+export interface LicenseStats {
+  totalLicenses: {
+    count: number;
+    currentMonthCount: number;
+    lastMonthCount: number;
+    percentageChange: number;
+  };
+  activeLicenses: {
+    count: number;
+    todayCount: number;
+    yesterdayCount: number;
+    dailyChange: number;
+  };
+  trialLicenses: {
+    count: number;
+    currentMonthCount: number;
+    lastMonthCount: number;
+    percentageChange: number;
+  };
+  expiredLicenses: {
+    currentCount: number;
+    currentMonthCount: number;
+    lastMonthCount: number;
+    percentageChange: number;
+  };
+  refundedAmount: {
+    currentAmount: number;
+    lastMonthAmount: number;
+    currentCount: number;
+    lastMonthCount: number;
+    percentageChange: number;
+  };
+  expiringInDays: {
+    count: number;
+    daysToExpire: number;
+  };
+  usageStatistics: {
+    activeToday: number;
+    activeThisWeek: number;
+    activeThisMonth: number;
+  };
+}
+
+/**
+ * Interface for basic stats with comparison
+ */
+export interface StatsWithComparison {
+  count: number;
+  percentageChange: number;
+}
+
+/**
+ * Interface for daily change stats
+ */
+export interface StatsWithDailyChange {
+  count: number;
+  dailyChange: number;
+}
+
+/**
+ * Interface for amount stats
+ */
+export interface AmountStats {
+  amount: number;
+  percentageChange: number;
+}
+
+/**
+ * Interface for expiring items stats
+ */
+export interface ExpiringStats {
+  count: number;
+  daysToExpire: number;
+}
+
+/**
+ * Interface for usage statistics
+ */
+export interface UsageStats {
+  activeToday: number;
+  activeThisWeek: number;
+  activeThisMonth: number;
+}
+
+/**
+ * Interface for license-specific stats with counts and percentages
+ */
+export interface LicenseCountStats {
+  count: number;
+  currentMonthCount: number;
+  lastMonthCount: number;
+  percentageChange: number;
+}
+
+/**
+ * Interface for license activity stats
+ */
+export interface LicenseActivityStats {
+  count: number;
+  todayCount: number;
+  yesterdayCount: number;
+  dailyChange: number;
+}
+
+/**
+ * Interface for expired license stats
+ */
+export interface ExpiredLicenseStats {
+  currentCount: number;
+  currentMonthCount: number;
+  lastMonthCount: number;
+  percentageChange: number;
+}
+
+/**
+ * Interface for refund stats
+ */
+export interface RefundStats {
+  currentAmount: number;
+  lastMonthAmount: number;
+  currentCount: number;
+  lastMonthCount: number;
+  percentageChange: number;
+}
+
+/**
+ * Utilities for transforming raw data into dashboard statistics
+ */
+export class DashboardDataTransformer {
+  /**
+   * Transform count data with percentage comparison
+   */
+  static transformCountWithComparison(
+    currentCount: number,
+    previousCount: number,
+  ): StatsWithComparison {
+    return {
+      count: currentCount,
+      percentageChange: StatisticsUtils.calculatePercentageChange(
+        currentCount,
+        previousCount,
+      ),
+    };
+  }
+
+  /**
+   * Transform count data with daily change
+   */
+  static transformCountWithDailyChange(
+    todayCount: number,
+    yesterdayCount: number,
+  ): StatsWithDailyChange {
+    return {
+      count: todayCount,
+      dailyChange: StatisticsUtils.calculateAbsoluteChange(
+        todayCount,
+        yesterdayCount,
+      ),
+    };
+  }
+
+  /**
+   * Transform amount data with percentage comparison
+   */
+  static transformAmountWithComparison(
+    currentAmount: number,
+    previousAmount: number,
+  ): AmountStats {
+    return {
+      amount: StatisticsUtils.roundToDecimal(currentAmount),
+      percentageChange: StatisticsUtils.calculatePercentageChange(
+        currentAmount,
+        previousAmount,
+      ),
+    };
+  }
+
+  /**
+   * Transform expiring items data
+   */
+  static transformExpiringData(
+    count: number,
+    daysToExpire = 30,
+  ): ExpiringStats {
+    return {
+      count,
+      daysToExpire,
+    };
+  }
+
+  /**
+   * Transform usage statistics
+   */
+  static transformUsageStats(
+    activeToday: number,
+    activeThisWeek: number,
+    activeThisMonth: number,
+  ): UsageStats {
+    return {
+      activeToday,
+      activeThisWeek,
+      activeThisMonth,
+    };
+  }
+
+  /**
+   * Calculate revenue summary from payment data
+   */
+  static calculateRevenueSummary(payments: Array<{ amount?: number }>): number {
+    const amounts = payments
+      .map((payment) => payment.amount || 0)
+      .filter((amount) => amount > 0);
+
+    return StatisticsUtils.calculateSum(amounts);
+  }
+
+  /**
+   * Group data by time period
+   */
+  static groupByTimePeriod<T extends { createdAt: string | Date }>(
+    items: T[],
+    period: 'day' | 'week' | 'month',
+  ): Record<string, T[]> {
+    const grouped: Record<string, T[]> = {};
+
+    items.forEach((item) => {
+      const date = new Date(item.createdAt);
+      let key: string;
+
+      switch (period) {
+        case 'day':
+          key = date.toISOString().split('T')[0]; // YYYY-MM-DD
+          break;
+        case 'week': {
+          const weekStart = new Date(date);
+
+          weekStart.setDate(date.getDate() - date.getDay());
+          key = weekStart.toISOString().split('T')[0];
+          break;
+        }
+        case 'month':
+          key = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}`;
+          break;
+        default:
+          key = date.toISOString().split('T')[0];
+      }
+
+      if (!grouped[key]) {
+        grouped[key] = [];
+      }
+      grouped[key].push(item);
+    });
+
+    return grouped;
+  }
+
+  /**
+   * Calculate trend indicators
+   */
+  static calculateTrendIndicators(
+    currentPeriodData: number[],
+    previousPeriodData: number[],
+  ) {
+    const currentAverage = StatisticsUtils.calculateAverage(currentPeriodData);
+    const previousAverage =
+      StatisticsUtils.calculateAverage(previousPeriodData);
+    const trend = StatisticsUtils.calculateTrend([
+      previousAverage,
+      currentAverage,
+    ]);
+
+    return {
+      currentAverage: StatisticsUtils.roundToDecimal(currentAverage),
+      previousAverage: StatisticsUtils.roundToDecimal(previousAverage),
+      trend,
+      percentageChange: StatisticsUtils.calculatePercentageChange(
+        currentAverage,
+        previousAverage,
+      ),
+    };
+  }
+
+  /**
+   * Format dashboard summary
+   */
+  static formatDashboardSummary(data: {
+    totalItems: number;
+    activeItems: number;
+    inactiveItems: number;
+    revenue: number;
+  }) {
+    const activePercentage =
+      data.totalItems > 0 ? (data.activeItems / data.totalItems) * 100 : 0;
+
+    return {
+      ...data,
+      activePercentage: StatisticsUtils.roundToDecimal(activePercentage),
+      formattedRevenue: StatisticsUtils.formatCurrency(data.revenue),
+      formattedTotalItems: StatisticsUtils.formatNumber(data.totalItems),
+    };
+  }
+
+  /**
+   * Transform license count data with monthly comparison
+   */
+  static transformLicenseCountStats(
+    totalCount: number,
+    currentMonthCount: number,
+    lastMonthCount: number,
+  ): LicenseCountStats {
+    return {
+      count: totalCount,
+      currentMonthCount,
+      lastMonthCount,
+      percentageChange: StatisticsUtils.calculatePercentageChange(
+        currentMonthCount,
+        lastMonthCount,
+      ),
+    };
+  }
+
+  /**
+   * Transform license activity data with daily comparison
+   */
+  static transformLicenseActivityStats(
+    totalActiveCount: number,
+    todayCount: number,
+    yesterdayCount: number,
+  ): LicenseActivityStats {
+    return {
+      count: totalActiveCount,
+      todayCount,
+      yesterdayCount,
+      dailyChange: StatisticsUtils.calculateAbsoluteChange(
+        todayCount,
+        yesterdayCount,
+      ),
+    };
+  }
+
+  /**
+   * Transform expired license data
+   */
+  static transformExpiredLicenseStats(
+    currentCount: number,
+    currentMonthCount: number,
+    lastMonthCount: number,
+  ): ExpiredLicenseStats {
+    return {
+      currentCount,
+      currentMonthCount,
+      lastMonthCount,
+      percentageChange: StatisticsUtils.calculatePercentageChange(
+        currentMonthCount,
+        lastMonthCount,
+      ),
+    };
+  }
+
+  /**
+   * Transform refund data with amount calculation
+   */
+  static transformRefundStats(
+    currentRefundedLicenses: number,
+    lastMonthRefundedLicenses: number,
+    averageRefundAmount = 100,
+  ): RefundStats {
+    const currentAmount = currentRefundedLicenses * averageRefundAmount;
+    const lastMonthAmount = lastMonthRefundedLicenses * averageRefundAmount;
+
+    return {
+      currentAmount,
+      lastMonthAmount,
+      currentCount: currentRefundedLicenses,
+      lastMonthCount: lastMonthRefundedLicenses,
+      percentageChange: StatisticsUtils.calculatePercentageChange(
+        currentAmount,
+        lastMonthAmount,
+      ),
+    };
+  }
+
+  /**
+   * Transform refund data with direct amounts and counts
+   */
+  static transformRefundStatsWithAmounts(
+    currentAmount: number,
+    lastMonthAmount: number,
+    currentCount: number,
+    lastMonthCount: number,
+  ): RefundStats {
+    return {
+      currentAmount: Math.round(currentAmount), // Keep as integer for currency
+      lastMonthAmount: Math.round(lastMonthAmount), // Keep as integer for currency
+      currentCount,
+      lastMonthCount,
+      percentageChange: StatisticsUtils.calculatePercentageChange(
+        currentAmount,
+        lastMonthAmount,
+      ),
+    };
+  }
+
+  /**
+   * Calculate active license percentage
+   */
+  static calculateActiveLicensePercentage(
+    activeCount: number,
+    totalCount: number,
+  ): number {
+    if (totalCount <= 0) return 0;
+
+    return StatisticsUtils.roundToDecimal((activeCount / totalCount) * 100);
+  }
+
+  /**
+   * Calculate trial license stats with comparison
+   */
+  static calculateTrialLicenseStats(
+    currentCount: number,
+    lastMonthCount: number,
+  ): StatsWithComparison {
+    return this.transformCountWithComparison(currentCount, lastMonthCount);
+  }
+
+  /**
+   * Calculate days until expiry for a given date
+   */
+  static calculateDaysUntilExpiry(expiryDate: Date): number {
+    const now = new Date();
+    const diffTime = expiryDate.getTime() - now.getTime();
+
+    return Math.ceil(diffTime / (1000 * 60 * 60 * 24));
+  }
+
+  /**
+   * Format license display name
+   */
+  static formatLicenseDisplayName(name?: string, licenseKey?: string): string {
+    return name || licenseKey || 'Unknown';
+  }
+
+  /**
+   * Format percentage change text with sign
+   */
+  static formatPercentageChangeText(percentageChange: number): string {
+    const sign = percentageChange >= 0 ? '+' : '';
+
+    return `${sign}${percentageChange.toFixed(1)}%`;
+  }
+
+  /**
+   * Format daily change text with sign
+   */
+  static formatDailyChangeText(dailyChange: number): string {
+    const sign = dailyChange >= 0 ? '+' : '';
+
+    return `${sign}${dailyChange}`;
+  }
+
+  /**
+   * Create license report metadata
+   */
+  static createLicenseReportMetadata(
+    workspaceId: string,
+    statistics: LicenseStats,
+    reportVersion = '1.0',
+  ) {
+    return {
+      generatedAt: new Date().toISOString(),
+      workspaceId,
+      statistics,
+      reportVersion,
+    };
+  }
+
+  /**
+   * Create license report data for database
+   */
+  static createLicenseReportData(
+    workspaceId: string,
+    statistics: LicenseStats,
+    reportVersion = '1.0',
+  ) {
+    const metadata = this.createLicenseReportMetadata(
+      workspaceId,
+      statistics,
+      reportVersion,
+    );
+
+    return {
+      name: `License Dashboard Statistics - ${new Date().toLocaleDateString()}`,
+      reportType: 'license',
+      notes: `Automated license dashboard statistics report generated at ${new Date().toISOString()}`,
+      metadata: metadata as unknown as JSON,
+      position: Date.now(),
+    };
+  }
+
+  /**
+   * Format license stats for console output
+   */
+  static formatLicenseStatsForConsole(stats: {
+    totalLicenses: LicenseCountStats;
+    activeLicenses: LicenseActivityStats;
+    expiredLicenses: ExpiredLicenseStats;
+    refundedAmount: RefundStats;
+    expiringInDays: ExpiringStats;
+    usageStatistics: UsageStats;
+    trialLicenses: LicenseCountStats;
+  }) {
+    const activePercentage = this.calculateActiveLicensePercentage(
+      stats.activeLicenses.count,
+      stats.totalLicenses.count,
+    );
+
+    return {
+      totalLicenses: {
+        ...stats.totalLicenses,
+        changeText: this.formatPercentageChangeText(
+          stats.totalLicenses.percentageChange,
+        ),
+      },
+      activeLicenses: {
+        ...stats.activeLicenses,
+        dailyChangeText: this.formatDailyChangeText(
+          stats.activeLicenses.dailyChange,
+        ),
+        activePercentage,
+      },
+      expiredLicenses: {
+        ...stats.expiredLicenses,
+        changeText: this.formatPercentageChangeText(
+          stats.expiredLicenses.percentageChange,
+        ),
+      },
+      refundedAmount: {
+        ...stats.refundedAmount,
+        changeText: this.formatPercentageChangeText(
+          stats.refundedAmount.percentageChange,
+        ),
+      },
+      expiringInDays: stats.expiringInDays,
+      usageStatistics: stats.usageStatistics,
+      trialLicenses: {
+        ...stats.trialLicenses,
+        changeText: this.formatPercentageChangeText(
+          stats.trialLicenses.percentageChange,
+        ),
+      },
+    };
+  }
+}

--- a/packages/twenty-server/src/mkt-core/utils/date-range.utils.ts
+++ b/packages/twenty-server/src/mkt-core/utils/date-range.utils.ts
@@ -1,0 +1,128 @@
+/**
+ * Date range utilities for calculating periods and time ranges
+ */
+export class DateRangeUtils {
+  /**
+   * Get the start and end dates for the current month
+   */
+  static getCurrentMonth(): { start: Date; end: Date } {
+    const now = new Date();
+    const start = new Date(now.getFullYear(), now.getMonth(), 1);
+    const end = new Date(
+      now.getFullYear(),
+      now.getMonth() + 1,
+      0,
+      23,
+      59,
+      59,
+      999,
+    );
+
+    return { start, end };
+  }
+
+  /**
+   * Get the start and end dates for the previous month
+   */
+  static getLastMonth(): { start: Date; end: Date } {
+    const now = new Date();
+    const start = new Date(now.getFullYear(), now.getMonth() - 1, 1);
+    const end = new Date(now.getFullYear(), now.getMonth(), 0, 23, 59, 59, 999);
+
+    return { start, end };
+  }
+
+  /**
+   * Get today's date range (00:00:00 to 23:59:59)
+   */
+  static getToday(): { start: Date; end: Date } {
+    const today = new Date();
+    const start = new Date(today);
+
+    start.setHours(0, 0, 0, 0);
+    const end = new Date(today);
+
+    end.setHours(23, 59, 59, 999);
+
+    return { start, end };
+  }
+
+  /**
+   * Get yesterday's date range
+   */
+  static getYesterday(): { start: Date; end: Date } {
+    const yesterday = new Date();
+
+    yesterday.setDate(yesterday.getDate() - 1);
+    const start = new Date(yesterday);
+
+    start.setHours(0, 0, 0, 0);
+    const end = new Date(yesterday);
+
+    end.setHours(23, 59, 59, 999);
+
+    return { start, end };
+  }
+
+  /**
+   * Get date range for the last N days
+   */
+  static getLastNDays(days: number): { start: Date; end: Date } {
+    const end = new Date();
+    const start = new Date(end);
+
+    start.setDate(start.getDate() - days);
+    start.setHours(0, 0, 0, 0);
+    end.setHours(23, 59, 59, 999);
+
+    return { start, end };
+  }
+
+  /**
+   * Get date range for the last N months
+   */
+  static getLastNMonths(months: number): { start: Date; end: Date } {
+    const end = new Date();
+    const start = new Date(end);
+
+    start.setMonth(start.getMonth() - months);
+    start.setDate(1);
+    start.setHours(0, 0, 0, 0);
+    end.setHours(23, 59, 59, 999);
+
+    return { start, end };
+  }
+
+  /**
+   * Get date range for future period (used for expiring items)
+   */
+  static getFuturePeriod(days: number): { start: Date; end: Date } {
+    const start = new Date();
+    const end = new Date(start.getTime() + days * 24 * 60 * 60 * 1000);
+
+    return { start, end };
+  }
+
+  /**
+   * Check if a date is within a range
+   */
+  static isDateInRange(date: Date, start: Date, end: Date): boolean {
+    return date >= start && date <= end;
+  }
+
+  /**
+   * Format date for database queries (ISO string)
+   */
+  static toISOString(date: Date): string {
+    return date.toISOString();
+  }
+
+  /**
+   * Get the difference in days between two dates
+   */
+  static getDaysDifference(start: Date, end: Date): number {
+    const diffTime = Math.abs(end.getTime() - start.getTime());
+
+    return Math.ceil(diffTime / (1000 * 60 * 60 * 24));
+  }
+}

--- a/packages/twenty-server/src/mkt-core/utils/index.ts
+++ b/packages/twenty-server/src/mkt-core/utils/index.ts
@@ -1,0 +1,24 @@
+// MKT Dashboard utilities - utilities for dashboard calculations and data transformation
+
+// Date utilities
+export { DateRangeUtils } from './date-range.utils';
+
+// Statistics utilities
+export { StatisticsUtils } from './statistics.utils';
+
+// Dashboard data transformation utilities
+export {
+  AmountStats,
+  DashboardDataTransformer,
+  ExpiredLicenseStats,
+  ExpiringStats,
+  LicenseActivityStats,
+  LicenseCountStats,
+  RefundStats,
+  StatsWithComparison,
+  StatsWithDailyChange,
+  UsageStats,
+} from './dashboard-data-transformer.utils';
+
+// Array processing utilities
+export { ArrayUtils } from './array.utils';

--- a/packages/twenty-server/src/mkt-core/utils/statistics.utils.ts
+++ b/packages/twenty-server/src/mkt-core/utils/statistics.utils.ts
@@ -1,0 +1,119 @@
+/**
+ * Mathematical utilities for statistical calculations
+ */
+export class StatisticsUtils {
+  /**
+   * Calculate percentage change between two numbers
+   */
+  static calculatePercentageChange(current: number, previous: number): number {
+    if (previous === 0) {
+      return current > 0 ? 100 : 0;
+    }
+
+    return Number((((current - previous) / previous) * 100).toFixed(2));
+  }
+
+  /**
+   * Calculate absolute change between two numbers
+   */
+  static calculateAbsoluteChange(current: number, previous: number): number {
+    return current - previous;
+  }
+
+  /**
+   * Calculate growth rate
+   */
+  static calculateGrowthRate(current: number, previous: number): number {
+    if (previous === 0) {
+      return current > 0 ? 1 : 0;
+    }
+
+    return Number((current / previous).toFixed(2));
+  }
+
+  /**
+   * Calculate average from an array of numbers
+   */
+  static calculateAverage(numbers: number[]): number {
+    if (numbers.length === 0) return 0;
+    const sum = numbers.reduce((acc, num) => acc + num, 0);
+
+    return Number((sum / numbers.length).toFixed(2));
+  }
+
+  /**
+   * Calculate sum from an array of numbers
+   */
+  static calculateSum(numbers: number[]): number {
+    return numbers.reduce((acc, num) => acc + num, 0);
+  }
+
+  /**
+   * Find maximum value in an array
+   */
+  static findMax(numbers: number[]): number {
+    return numbers.length > 0 ? Math.max(...numbers) : 0;
+  }
+
+  /**
+   * Find minimum value in an array
+   */
+  static findMin(numbers: number[]): number {
+    return numbers.length > 0 ? Math.min(...numbers) : 0;
+  }
+
+  /**
+   * Calculate median from an array of numbers
+   */
+  static calculateMedian(numbers: number[]): number {
+    if (numbers.length === 0) return 0;
+
+    const sorted = [...numbers].sort((a, b) => a - b);
+    const middle = Math.floor(sorted.length / 2);
+
+    if (sorted.length % 2 === 0) {
+      return (sorted[middle - 1] + sorted[middle]) / 2;
+    }
+
+    return sorted[middle];
+  }
+
+  /**
+   * Round number to specified decimal places
+   */
+  static roundToDecimal(value: number, decimals = 2): number {
+    return Number(value.toFixed(decimals));
+  }
+
+  /**
+   * Format number as currency
+   */
+  static formatCurrency(amount: number, currency = 'USD'): string {
+    return new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency: currency,
+    }).format(amount);
+  }
+
+  /**
+   * Format number with thousands separator
+   */
+  static formatNumber(value: number): string {
+    return new Intl.NumberFormat('en-US').format(value);
+  }
+
+  /**
+   * Calculate trend based on data points
+   */
+  static calculateTrend(dataPoints: number[]): 'up' | 'down' | 'stable' {
+    if (dataPoints.length < 2) return 'stable';
+
+    const first = dataPoints[0];
+    const last = dataPoints[dataPoints.length - 1];
+
+    if (last > first) return 'up';
+    if (last < first) return 'down';
+
+    return 'stable';
+  }
+}


### PR DESCRIPTION
- Implemented SeedMktReportModuleCommand to seed report data for workspaces.
- Created prefillMktReports function to insert initial report data.
- Developed utility classes for date range, statistics, array processing, and dashboard data transformation.
- Added comprehensive README documentation for utilities.
- Enhanced maintainability and reusability of code by separating logic into utility classes.